### PR TITLE
Apache sudo administration

### DIFF
--- a/manifests/classes/apache-administration.pp
+++ b/manifests/classes/apache-administration.pp
@@ -15,9 +15,8 @@ class apache::administration {
   $wwwpkgname = $apache::params::pkg
   $wwwuser    = $apache::params::user
 
-  common::concatfilepart { "sudoers.apache":
+  sudo::directive { "apache-administration":
     ensure => present,
-    file => "/etc/sudoers",
     content => template("apache/sudoers.apache.erb"),
     require => Group["apache-admin"],
   }


### PR DESCRIPTION
Take advantage of the new definition **sudo:: directive** that was added in the puppet-module sudo and that uses directive #includedir in **versions >= 1.7.2**

Feed-back welcome
