### PR TITLE
fix a typo in default a2enmode path that prevents it from working

### DIFF
--- a/manifests/definitions/module.pp
+++ b/manifests/definitions/module.pp
@@ -23,7 +23,7 @@ define apache::module ($ensure='present') {
         command => $operatingsystem ? {
           RedHat => "/usr/local/sbin/a2enmod ${name}",
           CentOS => "/usr/local/sbin/a2enmod ${name}",
-          default => "/usr//sbin/a2enmod ${name}"
+          default => "/usr/sbin/a2enmod ${name}"
         },
         unless  => "/bin/sh -c '[ -L ${apache::params::conf}/mods-enabled/${name}.load ] \\
           && [ ${apache::params::conf}/mods-enabled/${name}.load -ef ${apache::params::conf}/mods-available/${name}.load ]'",


### PR DESCRIPTION
fix a typo in default a2enmode path that prevents it from working on non-redhats with no path=>"/usr/sbin" defined in the manifests.
