### PR TITLE
apache: support mod_security on redhat 6

### DIFF
--- a/files/etc/httpd/mods-available/redhat6/security.load
+++ b/files/etc/httpd/mods-available/redhat6/security.load
@@ -1,0 +1,1 @@
+LoadModule security2_module modules/mod_security2.so


### PR DESCRIPTION
Adds a missing security.load file. The rpm package itself doesn't bring it, so we need to add it for apache to load the module.
