### PR TITLE
Print BalancerMember directives onto separate lines. 

### DIFF
--- a/templates/balancer.erb
+++ b/templates/balancer.erb
@@ -12,6 +12,7 @@ ProxyPassReverse <%= location %> <%= balancer %>/
 
 <% members.each do |member| -%>
     BalancerMember <%= proto %>://<%= member %><% params.each do |param| -%> <%= param %><% end -%>
+
 <% end -%>
 
 <% if standbyurl != "" -%>


### PR DESCRIPTION
Fixes this apache error: "BalancerMember can not have a balancer name when defined in a location"
