### PR TITLE
Option to change default Apache listening port, for SSL too

### DIFF
--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -68,8 +68,8 @@ class apache::base {
     require => Package["apache"],
   }
 
-  apache::listen { "80": ensure => present }
-  apache::namevhost { "*:80": ensure => present }
+  apache::listen { "${apache::params::port}": ensure => present }
+  apache::namevhost { "${apache::params::port}": ensure => present }
 
   apache::module {["alias", "auth_basic", "authn_file", "authz_default", "authz_groupfile", "authz_host", "authz_user", "autoindex", "dir", "env", "mime", "negotiation", "rewrite", "setenvif", "status", "cgi"]:
     ensure => present,

--- a/manifests/base/ssl.pp
+++ b/manifests/base/ssl.pp
@@ -9,8 +9,8 @@ It shouldn't be necessary to directly include this class.
 */
 class apache::base::ssl {
 
-  apache::listen { "443": ensure => present }
-  apache::namevhost { "*:443": ensure => present }
+  apache::listen { "${apache::params::ssl_port}": ensure => present }
+  apache::namevhost { "${apache::params::ssl_port}": ensure => present }
 
   file { "/usr/local/sbin/generate-ssl-cert.sh":
     source => "puppet:///modules/apache/generate-ssl-cert.sh",

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,7 +10,13 @@ the apache class behaves the same way on diffrent distributions.
 
 Example usage:
 
+  $apache_port = '127.0.0.1:8080'
   include apache
+
+Parameters:
+
+  $apache_port to specify on which main port Apache will listen. 
+  Defaults to '*:80'
 
 */
 class apache {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -38,4 +38,13 @@ class apache::params {
     /Debian|Ubuntu/ => "${log}/error.log",
   }
 
+  $port = $apache_port ? {
+    ''          => '*:80',
+    default     => $apache_port,
+  }
+
+  $ssl_port = $apache_ssl_port ? {
+    ''          => '*:443',
+    default     => $apache_ssl_port,
+  }
 }

--- a/manifests/ssl.pp
+++ b/manifests/ssl.pp
@@ -26,7 +26,16 @@ Class variables:
 
 Example usage:
 
+  $apache_ssl_port = '127.0.0.1:8443'
   include apache::ssl
+
+Parameters:
+
+  $apache_ssl_port to specify on which main port Apache will listen. 
+  Defaults to '*:443'
+
+
+
 
 */
 class apache::ssl inherits apache {


### PR DESCRIPTION
Hi,

I needed to change default Apache listening port when using your Puppet module. I saw in this issue https://github.com/camptocamp/puppet-apache/issues/15 that this little improvement could interest you, so look at my code and if it's okay for you to merge on your code, please accept this humble contribution. If you want me to modify the way it's done, tell me.

Bye.
