### PR TITLE
Fix shell commands which used posix

### DIFF
--- a/manifests/auth/htgroup.pp
+++ b/manifests/auth/htgroup.pp
@@ -1,5 +1,5 @@
 define apache::auth::htgroup (
-  $ensure="present", 
+  $ensure="present",
   $vhost=false,
   $groupFileLocation=false,
   $groupFileName="htgroup",
@@ -15,17 +15,18 @@ define apache::auth::htgroup (
       $_groupFileLocation = "${apache::params::root}/${vhost}/private"
     } else {
       fail "parameter vhost is require !"
-    }  
+    }
   }
 
   $_authGroupFile = "${_groupFileLocation}/${groupFileName}"
-  
+
   case $ensure {
 
     'present': {
-      exec {"! test -f $_authGroupFile && OPT='-c'; htgroup \$OPT $_authGroupFile $groupname $members":
-        unless => "grep -qi '^${groupname}: ${members}$' ${_authGroupFile}",
-        require => File[$_groupFileLocation],
+      exec {
+        "test ! -f $_authGroupFile && OPT='-c'; htgroup \$OPT $_authGroupFile $groupname $members":
+          unless    => "grep -qi '^${groupname}: ${members}$' ${_authGroupFile}",
+          require   => File[$_groupFileLocation],
       }
     }
 
@@ -39,7 +40,7 @@ define apache::auth::htgroup (
         command => "rm -f $_authGroupFile",
         onlyif => "wc -l $_authGroupFile |grep -q 0",
         refreshonly => true,
-      } 
+      }
     }
   }
 }

--- a/manifests/auth/htpasswd.pp
+++ b/manifests/auth/htpasswd.pp
@@ -1,5 +1,5 @@
 define apache::auth::htpasswd (
-  $ensure="present", 
+  $ensure="present",
   $vhost=false,
   $userFileLocation=false,
   $userFileName="htpasswd",
@@ -8,7 +8,7 @@ define apache::auth::htpasswd (
   $clearPassword=false){
 
   include apache::params
- 
+
   if $userFileLocation {
     $_userFileLocation = $userFileLocation
   } else {
@@ -18,9 +18,9 @@ define apache::auth::htpasswd (
       fail "parameter vhost is require !"
     }
   }
-  
+
   $_authUserFile = "${_userFileLocation}/${userFileName}"
-  
+
   case $ensure {
 
     'present': {
@@ -33,9 +33,10 @@ define apache::auth::htpasswd (
       }
 
       if $cryptPassword {
-        exec {"! test -f $_authUserFile && OPT='-c'; htpasswd -bp \$OPT $_authUserFile $username '$cryptPassword'":
-          unless => "grep -q ${username}:${cryptPassword} $_authUserFile",
-          require => File[$_userFileLocation],
+        exec {
+          "test ! -f $_authUserFile && OPT='-c'; htpasswd -bp \$OPT $_authUserFile $username '$cryptPassword'":
+            unless    => "grep -q ${username}:${cryptPassword} $_authUserFile",
+            require   => File[$_userFileLocation],
         }
       }
 
@@ -57,7 +58,7 @@ define apache::auth::htpasswd (
         command => "rm -f $_authUserFile",
         onlyif => "wc -l $_authUserFile |grep -q 0",
         refreshonly => true,
-      } 
+      }
     }
   }
 }


### PR DESCRIPTION
Hi

The calls for "! test -f /var/www/.../private/htpasswd" failed with an error message about the unknown command "!".
If you change "! test" to "test !", it works.
