### PR TITLE
Use R.I. Pienaar's concat module: https://github.com/ripienaar/puppet-concat

### DIFF
--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -10,6 +10,7 @@ It shouldn't be necessary to directly include this class.
 class apache::base {
 
   include apache::params
+  include concat::setup
 
   $access_log = $apache::params::access_log
   $error_log  = $apache::params::error_log
@@ -22,6 +23,8 @@ class apache::base {
     group => "root",
     require => Package["apache"],
   }
+
+  concat { "${apache::params::conf}/ports.conf": }
 
   file {"log directory":
     path => $apache::params::log,

--- a/manifests/listen.pp
+++ b/manifests/listen.pp
@@ -20,11 +20,9 @@ define apache::listen ($ensure='present') {
 
   include apache::params
 
-  common::concatfilepart { "apache-ports.conf-${name}":
-    ensure  => $ensure,
-    manage  => true,
+  concat::fragment { "apache-ports.conf-fragment-${name}":
+    target  => "${apache::params::conf}/ports.conf",
     content => "Listen ${name}\n",
-    file    => "${apache::params::conf}/ports.conf",
     require => Package["apache"],
     notify  => Service["apache"],
   }

--- a/manifests/namevhost.pp
+++ b/manifests/namevhost.pp
@@ -23,13 +23,10 @@ define apache::namevhost ($ensure='present') {
 
   include apache::params
 
-  common::concatfilepart { "apache-namevhost.conf-${name}":
-    ensure  => $ensure,
-    manage  => true,
+  concat::fragment { "apache-namevhost.conf-fragment-${name}":
+    target  => "${apache::params::conf}/ports.conf",
     content => "NameVirtualHost ${name}\n",
-    file    => "${apache::params::conf}/ports.conf",
     require => Package["apache"],
     notify  => Service["apache"],
   }
-
 }


### PR DESCRIPTION
This pull request is very much a matter of personal taste.  I'm already using R.I.'s concat module elsewhere, and I didn't want to have to pull in and manage another concat module.  This pull request converts the apache module to use R.I.'s concat.
