### PR TITLE
Add SELinux basic rules

### DIFF
--- a/files/selinux/httpdbase.te
+++ b/files/selinux/httpdbase.te
@@ -1,0 +1,16 @@
+
+module httpdbase 1.0;
+
+require {
+	type file_t;
+	type httpd_t;
+	type httpd_sys_content_t;
+	type logrotate_t;
+	class dir { read search getattr };
+}
+
+#============= httpd_t ==============
+allow httpd_t file_t:dir { search getattr };
+
+#============= logrotate_t ==============
+allow logrotate_t httpd_sys_content_t:dir read;

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,4 +19,9 @@ class apache {
     RedHat,CentOS:  { include apache::redhat}
     default: { fail "Unsupported operatingsystem ${operatingsystem}" }
   }
+
+  if $selinux == "true" {
+    include apache::selinux
+  }
+
 }

--- a/manifests/selinux.pp
+++ b/manifests/selinux.pp
@@ -1,0 +1,34 @@
+class apache::selinux {
+
+  case $operatingsystem {
+
+    RedHat,CentOS: {
+      case $lsbmajdistrelease {
+
+        "4","5": { }
+
+        default: {
+
+          # Basic SELinux rules to:
+          # -read vhost configuration files
+          # -logrotate
+          selinux::module { "httpdbase":
+            source => "puppet:///apache/selinux/httpdbase.te",
+            notify => Selmodule[ "httpdbase" ],
+          }
+
+          selmodule { "httpdbase":
+            ensure      => present,
+            syncversion => true,
+            require     => Exec[ "build selinux policy package httpdbase" ],
+          }
+
+        }
+      }
+    }
+
+    default: { }
+
+  }
+
+}


### PR DESCRIPTION
Add basic rules to allow Apache to parse vhosts configuration files and logrotate files.
Not sure that including apache::selinux from apache (instead of apache::redhat) is a good idea, as we don't use SELinux on Debian, yet.
