### PR TITLE
vhost.pp makes a reference to a2ensite. However, a2ensite (at least in C...

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -33,6 +33,14 @@ class apache::params {
     /Debian|Ubuntu/ => "${log}/access.log",
   }
 
+  $a2ensite = $operatingsystem ? {
+    /RedHat|CentOS/ => '/usr/local/sbin/a2ensite',
+    /Debian|Ubuntu/ => '/usr/sbin/a2ensite',
+  }
+
+
+
+
   $error_log = $operatingsystem ? {
     /RedHat|CentOS/ => "${log}/error_log",
     /Debian|Ubuntu/ => "${log}/error.log",


### PR DESCRIPTION
...entOS) is not defined in env path, so the manifest fails. By adding the suggested code, we can refere to it from vhost.pp using ${apache::params::a2ensite} in vhost.pp.

I have tested the aforementioned with CentOS successfully.
