### PR TITLE
Reorganise the way default vhosts are handled.

### DIFF
--- a/manifests/debian.pp
+++ b/manifests/debian.pp
@@ -57,9 +57,4 @@ class apache::debian inherits apache::base {
     require => Package["apache"],
   }
 
-  file { "${apache::params::conf}/sites-available/default-ssl":
-    ensure => absent,
-    force => true,
-  }
-
 }

--- a/manifests/vhost-ssl.pp
+++ b/manifests/vhost-ssl.pp
@@ -30,7 +30,6 @@ Parameters:
 - *$mode*: see apache::vhost
 - *$aliases*: see apache::vhost. The generated SSL certificate will have this
   list as DNS subjectAltName entries.
-- *$enable_default*: see apache::vhost
 - *$ip_address*: the ip address defined in the <VirtualHost> directive.
   Defaults to "*".
 - *$cert*: optional source URL of the certificate (see examples below), if the
@@ -118,7 +117,6 @@ define apache::vhost-ssl (
   $days="3650",
   $publish_csr=false,
   $sslonly=false,
-  $enable_default=true,
   $ports=['*:80'],
   $sslports=['*:443'],
   $accesslog_format="combined"
@@ -197,7 +195,6 @@ define apache::vhost-ssl (
     admin          => $admin,
     group          => $group,
     mode           => $mode,
-    enable_default => $enable_default,
     ports          => $ports,
     accesslog_format => $accesslog_format,
   }

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -12,7 +12,6 @@ define apache::vhost (
   $group="root",
   $mode=2570,
   $aliases=[],
-  $enable_default=true,
   $ports=['*:80'],
   $accesslog_format="combined"
 ) {
@@ -36,26 +35,6 @@ define apache::vhost (
     true    => "${wwwroot}/${name}/cgi-bin/",
     false   => false,
     default => $cgibin,
-  }
-
-  # check if default virtual host is enabled
-  if $enable_default == true {
-
-    exec { "enable default virtual host from ${name}":
-      command => "${apache::params::a2ensite} default",
-      unless  => "test -L ${apache::params::conf}/sites-enabled/000-default",
-      notify  => Exec["apache-graceful"],
-      require => Package["apache"],
-    }
-
-  } else {
-
-    exec { "disable default virtual host from ${name}":
-      command => "a2dissite default",
-      onlyif  => "test -L ${apache::params::conf}/sites-enabled/000-default",
-      notify  => Exec["apache-graceful"],
-      require => Package["apache"],
-    }
   }
 
   case $ensure {


### PR DESCRIPTION
- moved default vhost activation from apache::vhost to apache::base
  - don't remove site-available/default{,-ssl}: package upgrade will try to put
    them back and might break the configuration.
  - use our own site-available/default-vhost config instead

Warning: the enable_vhost parameters of apache::vhost and apache::vhost-ssl
no longer exists. You'll might have to edit your manifests after upgrading.
