### PR TITLE
I think the group needs to follow the same method used for wwwuser. Curr...

### DIFF
--- a/manifests/vhost-ssl.pp
+++ b/manifests/vhost-ssl.pp
@@ -105,7 +105,7 @@ define apache::vhost-ssl (
   $cgibin=true,
   $user="",
   $admin=$admin,
-  $group="root",
+  $group="",
   $mode=2570,
   $aliases=[],
   $ip_address="*",
@@ -136,6 +136,11 @@ define apache::vhost-ssl (
   $wwwuser = $user ? {
     ""      => $apache::params::user,
     default => $user,
+  }
+
+  $wwwgroup = $group ? {
+    ""      => $apache::params::group,
+    default => $group,
   }
 
   # used in ERB templates
@@ -195,7 +200,7 @@ define apache::vhost-ssl (
     docroot        => $docroot,
     user           => $wwwuser,
     admin          => $admin,
-    group          => $group,
+    group          => $wwwgroup,
     mode           => $mode,
     enable_default => $enable_default,
     ports          => $ports,


### PR DESCRIPTION
...ently, the group is set to root instead of inheriting the group from params.pp
