### PR TITLE
also load authz_svn module in dav_svn.load

### DIFF
--- a/files/etc/httpd/mods-available/redhat6/dav_svn.load
+++ b/files/etc/httpd/mods-available/redhat6/dav_svn.load
@@ -1,1 +1,2 @@
 LoadModule dav_svn_module modules/mod_dav_svn.so
+LoadModule authz_svn_module modules/mod_authz_svn.so


### PR DESCRIPTION
authz_svn has to be loaded after dav_svn, so it's not possible to put it in
its own .load file. The same tactic is used by the debian Apache package.
