### PR TITLE
Add empty namespace to top-scope variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/.project

--- a/manifests/administration.pp
+++ b/manifests/administration.pp
@@ -2,7 +2,7 @@ class apache::administration {
 
   include apache::params
 
-  $distro_specific_apache_sudo = $operatingsystem ? {
+  $distro_specific_apache_sudo = $::operatingsystem ? {
     /RedHat|CentOS/ => "/usr/sbin/apachectl, /sbin/service ${apache::params::pkg}",
     /Debian|Ubuntu/ => "/usr/sbin/apache2ctl",
   }

--- a/manifests/auth/basic/file/group.pp
+++ b/manifests/auth/basic/file/group.pp
@@ -36,7 +36,7 @@ define apache::auth::basic::file::group (
   file { "${apache::params::root}/${vhost}/conf/auth-basic-file-group-${fname}.conf":
     ensure => $ensure,
     content => template("apache/auth-basic-file-group.erb"),
-    seltype => $operatingsystem ? {
+    seltype => $::operatingsystem ? {
       "RedHat" => "httpd_config_t",
       "CentOS" => "httpd_config_t",
       default  => undef,

--- a/manifests/auth/basic/file/user.pp
+++ b/manifests/auth/basic/file/user.pp
@@ -35,7 +35,7 @@ define apache::auth::basic::file::user (
   file {"${apache::params::root}/${vhost}/conf/auth-basic-file-user-${fname}.conf":
     ensure => $ensure,
     content => template("apache/auth-basic-file-user.erb"),
-    seltype => $operatingsystem ? {
+    seltype => $::operatingsystem ? {
       "RedHat" => "httpd_config_t",
       "CentOS" => "httpd_config_t",
       default  => undef,

--- a/manifests/auth/basic/file/webdav/user.pp
+++ b/manifests/auth/basic/file/webdav/user.pp
@@ -39,7 +39,7 @@ define apache::auth::basic::file::webdav::user (
   file { "${apache::params::root}/${vhost}/conf/auth-basic-file-webdav-${fname}.conf":
     ensure     => $ensure,
     content    => template('apache/auth-basic-file-webdav-user.erb'),
-    seltype    => $operatingsystem ? {
+    seltype    => $::operatingsystem ? {
       'RedHat' => 'httpd_config_t',
       'CentOS' => 'httpd_config_t',
       default  => undef,

--- a/manifests/auth/basic/ldap.pp
+++ b/manifests/auth/basic/ldap.pp
@@ -37,7 +37,7 @@ define apache::auth::basic::ldap (
   file { "${apache::params::root}/${vhost}/conf/auth-basic-ldap-${fname}.conf":
     ensure => $ensure,
     content => template("apache/auth-basic-ldap.erb"),
-    seltype => $operatingsystem ? {
+    seltype => $::operatingsystem ? {
       "RedHat" => "httpd_config_t",
       "CentOS" => "httpd_config_t",
       default  => undef,

--- a/manifests/aw-stats.pp
+++ b/manifests/aw-stats.pp
@@ -15,11 +15,11 @@ define apache::aw-stats($ensure=present, $aliases=[]) {
     ensure  => $ensure,
     owner   => root,
     group   => root,
-    source  => $operatingsystem ? {
+    source  => $::operatingsystem ? {
       /RedHat|CentOS/ => "puppet:///modules/apache/awstats.rh.conf",
       /Debian|Ubuntu/ => "puppet:///modules/apache/awstats.deb.conf",
     },
-    seltype => $operatingsystem ? {
+    seltype => $::operatingsystem ? {
       "RedHat" => "httpd_config_t",
       "CentOS" => "httpd_config_t",
       default  => undef,

--- a/manifests/awstats.pp
+++ b/manifests/awstats.pp
@@ -15,7 +15,7 @@ class apache::awstats {
     require => Package["awstats"],
   }
 
-  case $operatingsystem {
+  case $::operatingsystem {
 
     Debian,Ubuntu: {
       cron { "update all awstats virtual hosts":
@@ -54,7 +54,7 @@ class apache::awstats {
       }
     }
 
-    default: { fail "Unsupported operatingsystem ${operatingsystem}" }
+    default: { fail "Unsupported operatingsystem ${::operatingsystem}" }
   }
 
 }

--- a/manifests/balancer.pp
+++ b/manifests/balancer.pp
@@ -88,7 +88,7 @@ define apache::balancer (
   file{ "${name} balancer on ${vhost}":
     ensure  => $ensure,
     content => template("apache/balancer.erb"),
-    seltype => $operatingsystem ? {
+    seltype => $::operatingsystem ? {
       "RedHat" => "httpd_config_t",
       "CentOS" => "httpd_config_t",
       default  => undef,

--- a/manifests/collectd.pp
+++ b/manifests/collectd.pp
@@ -19,7 +19,7 @@ Usage:
 */
 class apache::collectd {
 
-  if ($operatingsystem == "RedHat" or $operatingsystem == "CentOS") and $lsbmajdistrelease > "4" {
+  if ($::operatingsystem == "RedHat" or $::operatingsystem == "CentOS") and $::lsbmajdistrelease > "4" {
 
     package { "collectd-apache":
       ensure => present,

--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -40,7 +40,7 @@ define apache::conf($ensure=present, $filename="", $prefix="configuration", $con
   file{ "${name} configuration in ${path}":
     ensure => $ensure,
     content => "# file managed by puppet\n${configuration}\n",
-    seltype => $operatingsystem ? {
+    seltype => $::operatingsystem ? {
       "RedHat" => "httpd_config_t",
       "CentOS" => "httpd_config_t",
       default  => undef,

--- a/manifests/debian.pp
+++ b/manifests/debian.pp
@@ -52,7 +52,7 @@ class apache::debian inherits apache::base {
   }
 
   file { "${apache::params::conf}/conf.d/servername.conf":
-    content => "ServerName ${fqdn}\n",
+    content => "ServerName ${::fqdn}\n",
     notify  => Service["apache"],
     require => Package["apache"],
   }

--- a/manifests/dev.pp
+++ b/manifests/dev.pp
@@ -12,7 +12,7 @@
 class apache::dev {
 
   package { "apache-devel":
-    name    => $operatingsystem ? {
+    name    => $::operatingsystem ? {
       RedHat => "httpd-devel",
       CentOS => "httpd-devel",
     },

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,9 +14,9 @@ Example usage:
 
 */
 class apache {
-  case $operatingsystem {
+  case $::operatingsystem {
     Debian,Ubuntu:  { include apache::debian}
     RedHat,CentOS:  { include apache::redhat}
-    default: { fail "Unsupported operatingsystem ${operatingsystem}" }
+    default: { fail "Unsupported operatingsystem ${::operatingsystem}" }
   }
 }

--- a/manifests/module.pp
+++ b/manifests/module.pp
@@ -2,7 +2,7 @@ define apache::module ($ensure='present') {
 
   include apache::params
 
-  $a2enmod_deps = $operatingsystem ? {
+  $a2enmod_deps = $::operatingsystem ? {
     /RedHat|CentOS/ => [
       Package["apache"],
       File["/etc/httpd/mods-available"],
@@ -13,14 +13,14 @@ define apache::module ($ensure='present') {
     /Debian|Ubuntu/ => Package["apache"],
   }
 
-  if $selinux == "true" {
+  if $selinux == true {
     apache::redhat::selinux {$name: }
   }
 
   case $ensure {
     'present' : {
       exec { "a2enmod ${name}":
-        command => $operatingsystem ? {
+        command => $::operatingsystem ? {
           RedHat => "/usr/local/sbin/a2enmod ${name}",
           CentOS => "/usr/local/sbin/a2enmod ${name}",
           default => "/usr/sbin/a2enmod ${name}"
@@ -34,7 +34,7 @@ define apache::module ($ensure='present') {
 
     'absent': {
       exec { "a2dismod ${name}":
-        command => $operatingsystem ? {
+        command => $::operatingsystem ? {
           /RedHat|CentOS/ => "/usr/local/sbin/a2dismod ${name}",
           /Debian|Ubuntu/ => "/usr/sbin/a2dismod ${name}",
         },

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,44 +1,44 @@
 class apache::params {
 
-  $pkg = $operatingsystem ? {
+  $pkg = $::operatingsystem ? {
     /RedHat|CentOS/ => 'httpd',
     /Debian|Ubuntu/ => 'apache2',
   }
 
   $root = $apache_root ? {
-    "" => $operatingsystem ? {
+    "" => $::operatingsystem ? {
       /RedHat|CentOS/ => '/var/www/vhosts',
       /Debian|Ubuntu/ => '/var/www',
     },
     default => $apache_root
   }
 
-  $user = $operatingsystem ? {
+  $user = $::operatingsystem ? {
     /RedHat|CentOS/ => 'apache',
     /Debian|Ubuntu/ => 'www-data',
   }
 
-  $group = $operatingsystem ? {
+  $group = $::operatingsystem ? {
     /RedHat|CentOS/ => 'apache',
     /Debian|Ubuntu/ => 'www-data',
   }
 
-  $conf = $operatingsystem ? {
+  $conf = $::operatingsystem ? {
     /RedHat|CentOS/ => '/etc/httpd',
     /Debian|Ubuntu/ => '/etc/apache2',
   }
 
-  $log = $operatingsystem ? {
+  $log = $::operatingsystem ? {
     /RedHat|CentOS/ => '/var/log/httpd',
     /Debian|Ubuntu/ => '/var/log/apache2',
   }
 
-  $access_log = $operatingsystem ? {
+  $access_log = $::operatingsystem ? {
     /RedHat|CentOS/ => "${log}/access_log",
     /Debian|Ubuntu/ => "${log}/access.log",
   }
 
-  $a2ensite = $operatingsystem ? {
+  $a2ensite = $::operatingsystem ? {
     /RedHat|CentOS/ => '/usr/local/sbin/a2ensite',
     /Debian|Ubuntu/ => '/usr/sbin/a2ensite',
   }
@@ -46,7 +46,7 @@ class apache::params {
 
 
 
-  $error_log = $operatingsystem ? {
+  $error_log = $::operatingsystem ? {
     /RedHat|CentOS/ => "${log}/error_log",
     /Debian|Ubuntu/ => "${log}/error.log",
   }

--- a/manifests/proxypass.pp
+++ b/manifests/proxypass.pp
@@ -58,7 +58,7 @@ define apache::proxypass (
   file { "${name} proxypass on ${vhost}":
     ensure => $ensure,
     content => template("apache/proxypass.erb"),
-    seltype => $operatingsystem ? {
+    seltype => $::operatingsystem ? {
       "RedHat" => "httpd_config_t",
       "CentOS" => "httpd_config_t",
       default  => undef,

--- a/manifests/redhat.pp
+++ b/manifests/redhat.pp
@@ -13,7 +13,7 @@ class apache::redhat inherits apache::base {
   }
 
   # $httpd_pid_file is used in template logrotate-httpd.erb
-  $httpd_pid_file = $lsbmajdistrelease ? {
+  $httpd_pid_file = $::lsbmajdistrelease ? {
     /4|5/   => "/var/run/httpd.pid",
     default => "/var/run/httpd/httpd.pid",
   }
@@ -79,7 +79,7 @@ class apache::redhat inherits apache::base {
   # ssl.load was then changed to a template (see apache-ssl-redhat.pp)
   file { "${apache::params::conf}/mods-available":
     ensure => directory,
-    source => $lsbmajdistrelease ? {
+    source => $::lsbmajdistrelease ? {
       5 => "puppet:///modules/apache/etc/httpd/mods-available/redhat5/",
       6 => "puppet:///modules/apache/etc/httpd/mods-available/redhat6/",
     },

--- a/manifests/redhat/selinux.pp
+++ b/manifests/redhat/selinux.pp
@@ -37,7 +37,7 @@ define apache::redhat::selinux() {
     }
 
     suexec: {
-      if versioncmp($lsbmajdistrelease, 6) < 0 {
+      if versioncmp($::lsbmajdistrelease, 6) < 0 {
         selboolean { "httpd_suexec_disable_trans":
           value => "off",
           persistent => true,

--- a/manifests/redirectmatch.pp
+++ b/manifests/redirectmatch.pp
@@ -36,7 +36,7 @@ define apache::redirectmatch ($ensure="present", $regex, $url, $filename="", $vh
   file { "${name} redirect on ${vhost}":
     ensure  => $ensure,
     content => "# file managed by puppet\nRedirectMatch ${regex} ${url}\n",
-    seltype => $operatingsystem ? {
+    seltype => $::operatingsystem ? {
       "RedHat" => "httpd_config_t",
       "CentOS" => "httpd_config_t",
       default  => undef,

--- a/manifests/security.pp
+++ b/manifests/security.pp
@@ -1,6 +1,6 @@
 class apache::security {
 
-  case $operatingsystem {
+  case $::operatingsystem {
 
     RedHat,CentOS: {
       package { "mod_security":

--- a/manifests/ssl.pp
+++ b/manifests/ssl.pp
@@ -30,9 +30,9 @@ Example usage:
 
 */
 class apache::ssl inherits apache {
-  case $operatingsystem {
+  case $::operatingsystem {
     Debian,Ubuntu:  { include apache::ssl::debian}
     RedHat,CentOS:  { include apache::ssl::redhat}
-    default: { fail "Unsupported operatingsystem ${operatingsystem}" }
+    default: { fail "Unsupported operatingsystem ${::operatingsystem}" }
   }
 }

--- a/manifests/ssl/redhat.pp
+++ b/manifests/ssl/redhat.pp
@@ -18,11 +18,11 @@ class apache::ssl::redhat inherits apache::base::ssl {
     before => Exec["apache-graceful"],
   }
 
-	case $lsbmajdistrelease {
+	case $::lsbmajdistrelease {
     5,6: {
       file {"/etc/httpd/mods-available/ssl.load":
         ensure => present,
-        content => template("apache/ssl.load.rhel${lsbmajdistrelease}.erb"),
+        content => template("apache/ssl.load.rhel${::lsbmajdistrelease}.erb"),
         mode => 644,
         owner => "root",
         group => "root",

--- a/manifests/svnserver.pp
+++ b/manifests/svnserver.pp
@@ -1,6 +1,6 @@
 class apache::svnserver inherits apache::ssl {
 
-  case $operatingsystem {
+  case $::operatingsystem {
 
     Debian,Ubuntu:  {
       $pkglist = [ 'libapache2-svn' ]
@@ -11,7 +11,7 @@ class apache::svnserver inherits apache::ssl {
     }
 
     default: {
-      fail "Unsupported operatingsystem ${operatingsystem}"
+      fail "Unsupported operatingsystem ${::operatingsystem}"
     }
 
   }

--- a/manifests/userdirinstance.pp
+++ b/manifests/userdirinstance.pp
@@ -5,7 +5,7 @@ define apache::userdirinstance ($ensure=present, $vhost) {
   file { "${apache::params::root}/${vhost}/conf/userdir.conf":
     ensure => $ensure,
     source => 'puppet:///modules/apache/userdir.conf',
-    seltype => $operatingsystem ? {
+    seltype => $::operatingsystem ? {
       "RedHat" => "httpd_config_t",
       "CentOS" => "httpd_config_t",
       default  => undef,

--- a/manifests/vhost-ssl.pp
+++ b/manifests/vhost-ssl.pp
@@ -103,7 +103,7 @@ define apache::vhost-ssl (
   $docroot=false,
   $cgibin=true,
   $user="",
-  $admin=$admin,
+  $admin=$::admin,
   $group="",
   $mode=2570,
   $aliases=[],
@@ -164,7 +164,7 @@ define apache::vhost-ssl (
   if $cacert != false {
     $cacertfile = "${apache::params::root}/$name/ssl/cacert.crt"
   } else {
-    $cacertfile = $operatingsystem ? {
+    $cacertfile = $::operatingsystem ? {
       /RedHat|CentOS/ => "/etc/pki/tls/certs/ca-bundle.crt",
       Debian => "/etc/ssl/certs/ca-certificates.crt",
     }

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -49,7 +49,7 @@ define apache::vhost (
         owner   => root,
         group   => root,
         mode    => 644,
-        seltype => $operatingsystem ? {
+        seltype => $::operatingsystem ? {
           redhat => "httpd_config_t",
           CentOS => "httpd_config_t",
           default => undef,
@@ -63,7 +63,7 @@ define apache::vhost (
         owner  => root,
         group  => root,
         mode   => 755,
-        seltype => $operatingsystem ? {
+        seltype => $::operatingsystem ? {
           redhat => "httpd_sys_content_t",
           CentOS => "httpd_sys_content_t",
           default => undef,
@@ -79,7 +79,7 @@ define apache::vhost (
         },
         group  => $wwwgroup,
         mode   => $mode,
-        seltype => $operatingsystem ? {
+        seltype => $::operatingsystem ? {
           redhat => "httpd_config_t",
           CentOS => "httpd_config_t",
           default => undef,
@@ -92,7 +92,7 @@ define apache::vhost (
         owner  => $wwwuser,
         group  => $wwwgroup,
         mode   => $mode,
-        seltype => $operatingsystem ? {
+        seltype => $::operatingsystem ? {
           redhat => "httpd_sys_content_t",
           CentOS => "httpd_sys_content_t",
           default => undef,
@@ -127,7 +127,7 @@ define apache::vhost (
         owner  => $wwwuser,
         group  => $wwwgroup,
         mode   => $mode,
-        seltype => $operatingsystem ? {
+        seltype => $::operatingsystem ? {
           redhat => "httpd_sys_script_exec_t",
           CentOS => "httpd_sys_script_exec_t",
           default => undef,
@@ -163,7 +163,7 @@ define apache::vhost (
         owner  => root,
         group  => root,
         mode   => 755,
-        seltype => $operatingsystem ? {
+        seltype => $::operatingsystem ? {
           redhat => "httpd_log_t",
           CentOS => "httpd_log_t",
           default => undef,
@@ -179,7 +179,7 @@ define apache::vhost (
         owner => root,
         group => adm,
         mode => 644,
-        seltype => $operatingsystem ? {
+        seltype => $::operatingsystem ? {
           redhat => "httpd_log_t",
           CentOS => "httpd_log_t",
           default => undef,
@@ -193,7 +193,7 @@ define apache::vhost (
         owner   => $wwwuser,
         group   => $wwwgroup,
         mode    => $mode,
-        seltype => $operatingsystem ? {
+        seltype => $::operatingsystem ? {
           redhat => "httpd_sys_content_t",
           CentOS => "httpd_sys_content_t",
           default => undef,
@@ -215,13 +215,13 @@ define apache::vhost (
       }
 
       exec {"enable vhost ${name}":
-        command => $operatingsystem ? {
+        command => $::operatingsystem ? {
           RedHat => "${apache::params::a2ensite} ${name}",
           CentOS => "${apache::params::a2ensite} ${name}",
           default => "${apache::params::a2ensite} ${name}"
         },
         notify  => Exec["apache-graceful"],
-        require => [$operatingsystem ? {
+        require => [$::operatingsystem ? {
           redhat => File["${apache::params::a2ensite}"],
           CentOS => File["${apache::params::a2ensite}"],
           default => Package[$apache::params::pkg]},
@@ -253,13 +253,13 @@ define apache::vhost (
       }
 
       exec { "disable vhost ${name}":
-        command => $operatingsystem ? {
+        command => $::operatingsystem ? {
           RedHat => "/usr/local/sbin/a2dissite ${name}",
           CentOS => "/usr/local/sbin/a2dissite ${name}",
           default => "/usr/sbin/a2dissite ${name}"
         },
         notify  => Exec["apache-graceful"],
-        require => [$operatingsystem ? {
+        require => [$::operatingsystem ? {
           redhat => File["${apache::params::a2ensite}"],
           CentOS => File["${apache::params::a2ensite}"],
           default => Package[$apache::params::pkg]}],

--- a/manifests/webdav/base.pp
+++ b/manifests/webdav/base.pp
@@ -1,6 +1,6 @@
 class apache::webdav::base {
 
-  case $operatingsystem {
+  case $::operatingsystem {
 
     Debian,Ubuntu:  {
 

--- a/manifests/webdav/instance.pp
+++ b/manifests/webdav/instance.pp
@@ -22,7 +22,7 @@ define apache::webdav::instance ($ensure=present, $vhost, $directory=false,$mode
   file { "${apache::params::root}/${vhost}/conf/webdav-${name}.conf":
     ensure => $ensure,
     content => template("apache/webdav-config.erb"),
-    seltype => $operatingsystem ? {
+    seltype => $::operatingsystem ? {
       "RedHat" => "httpd_config_t",
       "CentOS" => "httpd_config_t",
       default  => undef,

--- a/manifests/webdav/ssl.pp
+++ b/manifests/webdav/ssl.pp
@@ -1,6 +1,6 @@
 class apache::webdav::ssl inherits apache::ssl {
-  case $operatingsystem {
+  case $::operatingsystem {
     Debian,Ubuntu:  { include apache::webdav::ssl::debian}
-    default: { fail "Unsupported operatingsystem ${operatingsystem}" }
+    default: { fail "Unsupported operatingsystem ${::operatingsystem}" }
   }
 }

--- a/manifests/webdav/ssl/debian.pp
+++ b/manifests/webdav/ssl/debian.pp
@@ -1,6 +1,6 @@
 class apache::webdav::ssl::debian inherits apache::webdav::base {
 
-  case $lsbdistcodename {
+  case $::lsbdistcodename {
     etch: {
       # cf: http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=420101
       file {"/var/lock/apache2":

--- a/manifests/webdav/svn.pp
+++ b/manifests/webdav/svn.pp
@@ -7,7 +7,7 @@ define apache::webdav::svn ($ensure, $vhost, $parentPath, $confname) {
   file { "${apache::params::root}/${vhost}/conf/${confname}.conf":
     ensure  => $ensure,
     content => template("apache/webdav-svn.erb"),
-    seltype => $operatingsystem ? {
+    seltype => $::operatingsystem ? {
       "RedHat" => "httpd_config_t",
       "CentOS" => "httpd_config_t",
       default  => undef,


### PR DESCRIPTION
Following the style guide
(http://docs.puppetlabs.com/guides/style_guide.html#namespacing-variables),
adding the empty namespace to all top-scope variables.
Adding the .gitignore to Eclipse project files.
