### PR TITLE
force removal of /var/www/cgi-bin

### DIFF
--- a/manifests/redhat.pp
+++ b/manifests/redhat.pp
@@ -101,6 +101,7 @@ class apache::redhat inherits apache::base {
   file {"/var/www/cgi-bin":
     ensure  => absent,
     require => Package["apache"],
+    force   => true,
   }
 
   # no idea why redhat choose to put this file there. apache fails if it's


### PR DESCRIPTION
Without the force parameter, Puppet would generate a warning during every run.
According to the PuppetLabs documentation for the file type, force must
be set to remove a directory when ensure => absent.
