### PR TITLE
apache: create default vhost directory for everyone

### DIFF
--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -97,16 +97,24 @@ class apache::base {
   }
 
   if $apache_disable_default_vhost {
+
     file { "${apache::params::conf}/sites-enabled/000-default-vhost":
       ensure => absent,
       notify => Exec['apache-graceful'],
     }
+
   } else {
+
     file { "${apache::params::conf}/sites-enabled/000-default-vhost":
       ensure => link,
       target => "${apache::params::conf}/sites-available/default-vhost",
       notify => Exec['apache-graceful'],
     }
+
+    file { "${apache::params::root}/html": 
+      ensure  => directory,
+    }
+
   }
 
   exec { "apache-graceful":

--- a/manifests/debian.pp
+++ b/manifests/debian.pp
@@ -45,10 +45,6 @@ class apache::debian inherits apache::base {
     ensure => absent,
   }
 
-  file { "${apache::params::root}/html":
-    ensure  => directory,
-  }
-
   file { "${apache::params::root}/html/index.html":
     ensure  => present,
     owner   => root,


### PR DESCRIPTION
It was done in debian, but we need the same for all distributions (currently
debian + redhat). We only create that directory if $apache_disable_default_vhost
is not set, but we don't remove it otherwise (which I feel might be a bit bold).
