### PR TITLE
allow to have specific configuration for ssl and non-ssl part

### DIFF
--- a/manifests/vhost/ssl.pp
+++ b/manifests/vhost/ssl.pp
@@ -181,6 +181,7 @@ define apache::vhost::ssl (
 
 
   # call parent definition to actually do the virtualhost setup.
+  $is_ssl = true
   apache::vhost {$name:
     ensure         => $ensure,
     config_file    => $config_file,
@@ -213,6 +214,40 @@ define apache::vhost::ssl (
       seltype => "cert_t",
       require => [File["${apache::params::root}/${name}"]],
     }
+    if !$sslonly {
+      file { "${apache::params::root}/${name}/conf/ssl":
+        ensure    => directory,
+        owner     => $admin ? {
+          ''      => $wwwuser,
+          default => $admin,
+        },
+        group     => $wwwgroup,
+        mode      => $mode,
+        seltype   => $::operatingsystem ? {
+          redhat  => 'httpd_config_t',
+          CentOS  => 'httpd_config_t',
+          default => undef,
+        },
+        require => [File["${apache::params::root}/${name}/conf"]],
+      }
+
+      file { "${apache::params::root}/${name}/conf/non-ssl":
+        ensure    => directory,
+        owner     => $admin ? {
+          ''      => $wwwuser,
+          default => $admin,
+        },
+        group     => $wwwgroup,
+        mode      => $mode,
+        seltype   => $::operatingsystem ? {
+          redhat  => 'httpd_config_t',
+          CentOS  => 'httpd_config_t',
+          default => undef,
+        },
+        require => [File["${apache::params::root}/${name}/conf"]],
+      }
+    }
+
 
     # template file used to generate SSL key, cert and csr.
     file { "${apache::params::root}/${name}/ssl/ssleay.cnf":

--- a/templates/vhost-ssl.erb
+++ b/templates/vhost-ssl.erb
@@ -14,6 +14,7 @@
   CustomLog <%= wwwroot %>/<%= name %>/logs/access.log combined
 
   Include <%= wwwroot %>/<%= name%>/conf/*.conf
+  Include <%= wwwroot %>/<%= name%>/conf/ssl/*.conf
 
   SSLEngine On
   SSLCertificateFile <%= certfile %>

--- a/templates/vhost.erb
+++ b/templates/vhost.erb
@@ -14,7 +14,9 @@
   CustomLog <%= wwwroot %>/<%= name %>/logs/access.log "<%= accesslog_format %>"
 
   Include <%= wwwroot %>/<%= name%>/conf/*.conf
-
+<% if is_ssl -%>
+  Include <%= wwwroot %>/<%= name%>/conf/non-ssl/*.conf
+<% end -%>
 <% if cgipath -%>
   ScriptAlias /cgi-bin/ <%= cgipath %>
   <Directory <%= cgipath %>>


### PR DESCRIPTION
For now, the vhost conf directory is included in both SSL and non-SSL
part. This may lead to some bad configuration, like WSGI daemon declared
twice.
This patch creates, only for vhost::ssl, two new directories, conf/ssl
and conf/non-ssl to allow configuration sepraration. It creates it only
if vhost is available on both SSL and non-SSL.
