### PR TITLE
Fix errors according to puppet-lint 0.3.2

### DIFF
--- a/manifests/auth/basic/file/group.pp
+++ b/manifests/auth/basic/file/group.pp
@@ -1,5 +1,5 @@
 define apache::auth::basic::file::group (
-  $ensure="present", 
+  $ensure="present",
   $authname=false,
   $vhost,
   $location="/",
@@ -10,7 +10,7 @@ define apache::auth::basic::file::group (
   $fname = regsubst($name, "\s", "_", "G")
 
   include apache::params
- 
+
   if defined(Apache::Module["authn_file"]) {} else {
     apache::module {"authn_file": }
   }

--- a/manifests/auth/basic/file/user.pp
+++ b/manifests/auth/basic/file/user.pp
@@ -1,5 +1,5 @@
 define apache::auth::basic::file::user (
-  $ensure="present", 
+  $ensure="present",
   $authname=false,
   $vhost,
   $location="/",
@@ -9,8 +9,8 @@ define apache::auth::basic::file::user (
   $fname = regsubst($name, "\s", "_", "G")
 
   include apache::params
- 
-  if defined(Apache::Module["authn_file"]) {} else {
+
+  if !defined(Apache::Module["authn_file"]) {
     apache::module {"authn_file": }
   }
 

--- a/manifests/auth/basic/ldap.pp
+++ b/manifests/auth/basic/ldap.pp
@@ -1,5 +1,5 @@
 define apache::auth::basic::ldap (
-  $ensure="present", 
+  $ensure="present",
   $authname=false,
   $vhost,
   $location="/",

--- a/manifests/auth/htgroup.pp
+++ b/manifests/auth/htgroup.pp
@@ -1,5 +1,5 @@
 define apache::auth::htgroup (
-  $ensure="present", 
+  $ensure="present",
   $vhost=false,
   $groupFileLocation=false,
   $groupFileName="htgroup",
@@ -15,11 +15,11 @@ define apache::auth::htgroup (
       $_groupFileLocation = "${apache::params::root}/${vhost}/private"
     } else {
       fail "parameter vhost is require !"
-    }  
+    }
   }
 
   $_authGroupFile = "${_groupFileLocation}/${groupFileName}"
-  
+
   case $ensure {
 
     'present': {
@@ -39,7 +39,7 @@ define apache::auth::htgroup (
         command     => "rm -f ${_authGroupFile}",
         onlyif      => "wc -l ${_authGroupFile} | egrep -q '^0[^0-9]'",
         refreshonly => true,
-      } 
+      }
     }
   }
 }

--- a/manifests/auth/htpasswd.pp
+++ b/manifests/auth/htpasswd.pp
@@ -1,5 +1,5 @@
 define apache::auth::htpasswd (
-  $ensure="present", 
+  $ensure="present",
   $vhost=false,
   $userFileLocation=false,
   $userFileName="htpasswd",
@@ -8,7 +8,7 @@ define apache::auth::htpasswd (
   $clearPassword=false){
 
   include apache::params
- 
+
   if $userFileLocation {
     $_userFileLocation = $userFileLocation
   } else {
@@ -18,9 +18,9 @@ define apache::auth::htpasswd (
       fail "parameter vhost is require !"
     }
   }
-  
+
   $_authUserFile = "${_userFileLocation}/${userFileName}"
-  
+
   case $ensure {
 
     'present': {
@@ -57,7 +57,7 @@ define apache::auth::htpasswd (
         command     => "rm -f ${_authUserFile}",
         onlyif      => "wc -l ${_authUserFile} | egrep -q '^0[^0-9]'",
         refreshonly => true,
-      } 
+      }
     }
   }
 }

--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -125,7 +125,7 @@ class apache::base {
       notify => Exec['apache-graceful'],
     }
 
-    file { "${apache::params::root}/html": 
+    file { "${apache::params::root}/html":
       ensure  => directory,
     }
 

--- a/manifests/ssl/redhat.pp
+++ b/manifests/ssl/redhat.pp
@@ -18,7 +18,7 @@ class apache::ssl::redhat inherits apache::base::ssl {
     before => Exec["apache-graceful"],
   }
 
-	case $::lsbmajdistrelease {
+  case $::lsbmajdistrelease {
     5,6: {
       file {"/etc/httpd/mods-available/ssl.load":
         ensure => present,
@@ -28,7 +28,7 @@ class apache::ssl::redhat inherits apache::base::ssl {
         group => "root",
         seltype => "httpd_config_t",
         require => File["/etc/httpd/mods-available"],
-			}
+      }
     }
   }
 }

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -99,7 +99,7 @@ define apache::vhost (
         },
         require => [File["${apache::params::root}/${name}"]],
       }
- 
+
       if $htdocs {
         File["${apache::params::root}/${name}/htdocs"] {
           source  => $htdocs,
@@ -151,7 +151,7 @@ define apache::vhost (
           } else {
             # default vhost template
             File["${apache::params::conf}/sites-available/${name}"] {
-              content => template("apache/vhost.erb"), 
+              content => template("apache/vhost.erb"),
             }
           }
         }
@@ -235,12 +235,12 @@ define apache::vhost (
       }
     }
 
-    absent:{
+    absent: {
       file { "${apache::params::conf}/sites-enabled/${name}":
         ensure  => absent,
         require => Exec["disable vhost ${name}"]
       }
-      
+
       file { "${apache::params::conf}/sites-available/${name}":
         ensure  => absent,
         require => Exec["disable vhost ${name}"]
@@ -263,12 +263,12 @@ define apache::vhost (
           redhat => File["${apache::params::a2ensite}"],
           CentOS => File["${apache::params::a2ensite}"],
           default => Package[$apache::params::pkg]}],
-        onlyif => "/bin/sh -c '[ -L ${apache::params::conf}/sites-enabled/${name} ] \\
-          && [ ${apache::params::conf}/sites-enabled/${name} -ef ${apache::params::conf}/sites-available/${name} ]'",
+          onlyif => "/bin/sh -c '[ -L ${apache::params::conf}/sites-enabled/${name} ] \\
+            && [ ${apache::params::conf}/sites-enabled/${name} -ef ${apache::params::conf}/sites-available/${name} ]'",
       }
-   }
+    }
 
-   disabled: {
+    disabled: {
       exec { "disable vhost ${name}":
         command => $operatingsystem ? {
           RedHat => "/usr/local/sbin/a2dissite ${name}",

--- a/manifests/webdav/instance.pp
+++ b/manifests/webdav/instance.pp
@@ -1,7 +1,7 @@
 define apache::webdav::instance ($ensure=present, $vhost, $directory=false,$mode=2755) {
 
   include apache::params
- 
+
   if $directory {
     $davdir = "${directory}/webdav-${name}"
   } else {

--- a/manifests/webdav/ssl/debian.pp
+++ b/manifests/webdav/ssl/debian.pp
@@ -10,6 +10,6 @@ class apache::webdav::ssl::debian inherits apache::webdav::base {
         mode    => 755,
       }
     }
-  } 
+  }
 
 }


### PR DESCRIPTION
Fix errors (only style errors, mostly [trailing whitespace](http://puppet-lint.com/checks/trailing_whitespace/)) according to [puppet-lint](http://puppet-lint.com/) 0.3.2.

There are a lot of warnings as well but this patchset only copes with the (default) errors found by puppet-lint.
