### PR TITLE
apache::redhat: empty instead of removing conf files

### DIFF
--- a/manifests/redhat.pp
+++ b/manifests/redhat.pp
@@ -121,7 +121,12 @@ class apache::redhat inherits apache::base {
   # no idea why redhat choose to put this file there. apache fails if it's
   # present and mod_proxy isn't...
   file { "${apache::params::conf}/conf.d/proxy_ajp.conf":
-    ensure  => absent,
+    ensure  => present,
+    content => "# File managed by puppet
+#
+# This file is installed by 'httpd' RedHat package but we're not using it. We
+# must keep it here to avoid it being recreated on package upgrade.
+",
     require => Package['apache'],
     notify  => Exec['apache-graceful'],
   }

--- a/manifests/ssl/redhat.pp
+++ b/manifests/ssl/redhat.pp
@@ -5,7 +5,13 @@ class apache::ssl::redhat inherits apache::base::ssl {
   }
 
   file {'/etc/httpd/conf.d/ssl.conf':
-    ensure  => absent,
+    ensure  => present,
+    content => "# File managed by puppet
+#
+# This file is installed by the 'mod_ssl' RedHat package but we put this
+# configuration in mods-available/ssl.load instead. We must keep this file
+# here to avoid it being recreated on package upgrade.
+",
     require => Package['mod_ssl'],
     notify  => Service['apache'],
     before  => Exec['apache-graceful'],


### PR DESCRIPTION
The files ssl.conf and proxy_ajp.conf must not be removed because
they will be recreated on package upgrade. This most probably will
break a server's config. By emptying the files (with a comment)
instead, RedHat won't overwrite our change.
