### PR TITLE
Validate vhosts with validate_augeas

### DIFF
--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -136,23 +136,21 @@ define apache::vhost (
       }
 
       case $config_file {
-
         default: {
-          File["${apache::params::conf}/sites-available/${name}"] {
-            source => $config_file,
-          }
-        }
-        "": {
-
-          if $config_content {
             File["${apache::params::conf}/sites-available/${name}"] {
-              content => $config_content,
+              source => $config_file,
             }
+        }
+        '': {
+          if $config_content {
+              $file_content = $config_content
           } else {
             # default vhost template
-            File["${apache::params::conf}/sites-available/${name}"] {
-              content => template("apache/vhost.erb"), 
-            }
+            $file_content = template('apache/vhost.erb')
+          }
+          validate_augeas($file_content, 'Httpd.lns')
+          File["${apache::params::conf}/sites-available/${name}"] {
+            content => $file_content,
           }
         }
       }

--- a/manifests/vhost/ssl.pp
+++ b/manifests/vhost/ssl.pp
@@ -180,26 +180,31 @@ define apache::vhost::ssl (
 
 
   # call parent definition to actually do the virtualhost setup.
-  apache::vhost {$name:
-    ensure         => $ensure,
-    config_file    => $config_file,
-    config_content => $config_content ? {
-      false => $sslonly ? {
-        false => template("apache/vhost.erb", "apache/vhost-ssl.erb"),
-        default => template("apache/vhost-redirect-ssl.erb", "apache/vhost-ssl.erb"),
-      },
-      default      => $config_content,
+  $_config_content = $config_content ? {
+    false => $sslonly ? {
+      false   => template('apache/vhost.erb', 'apache/vhost-ssl.erb'),
+      default => template('apache/vhost-redirect-ssl.erb',
+                          'apache/vhost-ssl.erb'),
     },
-    aliases        => $aliases,
-    htdocs         => $htdocs,
-    conf           => $conf,
-    readme         => $readme,
-    docroot        => $docroot,
-    user           => $wwwuser,
-    admin          => $admin,
-    group          => $wwwgroup,
-    mode           => $mode,
-    ports          => $ports,
+    default      => $config_content,
+  }
+
+  validate_augeas($_config_content, 'Httpd.lns')
+
+  apache::vhost {$name:
+    ensure           => $ensure,
+    config_file      => $config_file,
+    aliases          => $aliases,
+    htdocs           => $htdocs,
+    conf             => $conf,
+    config_content   => $_config_content,
+    readme           => $readme,
+    docroot          => $docroot,
+    user             => $wwwuser,
+    admin            => $admin,
+    group            => $wwwgroup,
+    mode             => $mode,
+    ports            => $ports,
     accesslog_format => $accesslog_format,
   }
 


### PR DESCRIPTION
This uses the new `validate_augeas` function from stdlib to validate the contents of vhosts at compilation time, using the `Httpd.lns` Augeas lens.
