### PR TITLE
Add PATH to Exec resource

### DIFF
--- a/manifests/debian.pp
+++ b/manifests/debian.pp
@@ -4,6 +4,7 @@ class apache::debian inherits apache::base {
 
   # BEGIN inheritance from apache::base
   Exec["apache-graceful"] {
+    path => '/usr/sbin',
     command => "apache2ctl graceful",
     onlyif => "apache2ctl configtest",
   }


### PR DESCRIPTION
Fixes the following error on Debian systems:

> Error: Failed to apply catalog: Parameter onlyif failed on Exec[apache-graceful]: 'apache2ctl configtest' is not qualified and no path was specified. Please qualify the command or specify a path.
