### PR TITLE
Fix quoting errors in userdir and userdirinstance classes

### DIFF
--- a/manifests/userdir.pp
+++ b/manifests/userdir.pp
@@ -27,7 +27,7 @@ class apache::userdir {
   file {'/etc/skel/public_html/README':
     ensure  => present,
     require => File['/etc/skel/public_html'],
-    source  => 'puppet:///modules/${module_name}/README_userdir',
+    source  => "puppet:///modules/${module_name}/README_userdir",
   }
 
   apache::module { 'userdir':

--- a/manifests/userdirinstance.pp
+++ b/manifests/userdirinstance.pp
@@ -4,7 +4,7 @@ define apache::userdirinstance ($ensure=present, $vhost) {
 
   file { "${apache::params::root}/${vhost}/conf/userdir.conf":
     ensure => $ensure,
-    source => 'puppet:///modules/${module_name}/userdir.conf',
+    source => "puppet:///modules/${module_name}/userdir.conf",
     seltype => $::operatingsystem ? {
       "RedHat" => "httpd_config_t",
       "CentOS" => "httpd_config_t",


### PR DESCRIPTION
There have been two wrongly quoted parameters in the `userdir` and `userdirinstance` classes which contain variables for string interpolation but have used single quotes which won't interpolate strings.
