### PR TITLE
Escape ENV::HOME to stop puppet 3 treating it as a variable

### DIFF
--- a/templates/ssleay.cnf.erb
+++ b/templates/ssleay.cnf.erb
@@ -3,7 +3,7 @@
 # SSLeay example configuration file.
 #
 
-RANDFILE                = $ENV::HOME/.rnd
+RANDFILE                = \$ENV\:\:HOME/.rnd
 
 [ req ]
 default_bits            = 2048


### PR DESCRIPTION
Escape ENV::HOME to stop puppet 3 treating it as a variable
