### PR TITLE
Use apache::vhost::ssl also with ubuntu

### DIFF
--- a/manifests/vhost/ssl.pp
+++ b/manifests/vhost/ssl.pp
@@ -180,7 +180,7 @@ define apache::vhost::ssl (
   } else {
     $cacertfile = $::operatingsystem ? {
       /RedHat|CentOS/ => '/etc/pki/tls/certs/ca-bundle.crt',
-      Debian          => '/etc/ssl/certs/ca-certificates.crt',
+      /Debian|Ubuntu/ => '/etc/ssl/certs/ca-certificates.crt',
     }
   }
 


### PR DESCRIPTION
- Ubuntu uses the same paths for storing certificates
  as Debian
