### PR TITLE
auth::basic::file: add validates on some parameters

### DIFF
--- a/manifests/auth/basic/file/group.pp
+++ b/manifests/auth/basic/file/group.pp
@@ -7,6 +7,8 @@ define apache::auth::basic::file::group (
   $authGroupFile=false,
   $groups){
 
+  validate_string($groups)
+
   $fname = regsubst($name, "\s", "_", "G")
 
   include apache::params

--- a/manifests/auth/basic/file/user.pp
+++ b/manifests/auth/basic/file/user.pp
@@ -6,6 +6,8 @@ define apache::auth::basic::file::user (
   $authUserFile=false,
   $users="valid-user"){
 
+  validate_string($users)
+
   $fname = regsubst($name, "\s", "_", "G")
 
   include apache::params

--- a/manifests/auth/basic/file/webdav/user.pp
+++ b/manifests/auth/basic/file/webdav/user.pp
@@ -6,9 +6,14 @@ define apache::auth::basic::file::webdav::user (
   $authUserFile=false,
   $rw_users='valid-user',
   $limits='GET HEAD OPTIONS PROPFIND',
-  $ro_users=false,
+  $ro_users='',
   $allow_anonymous=false,
   $restricted_access=[]) {
+
+  validate_string($rw_users)
+  validate_string($limits)
+  validate_string($ro_users)
+  validate_array($restricted_access)
 
   $fname = regsubst($name, '\s', '_', 'G')
 

--- a/templates/auth-basic-file-webdav-user.erb
+++ b/templates/auth-basic-file-webdav-user.erb
@@ -5,7 +5,7 @@
   AuthBasicProvider file
   AuthUserFile <%= _authUserFile %>
   require <%= _users %>
-<% if ro_users -%>
+<% if ro_users != '' -%>
   <Limit <%= limits %>>
     require user <%= ro_users %>
   </Limit>
@@ -15,7 +15,9 @@
 <% unless restricted_access.empty? -%>
     Order deny,allow
     Deny from all
-    <%= restricted_access.collect! {|i| "Allow from #{i}"} %>
+<% restricted_access.each do |access| -%>
+    Allow from <%= access %>
+<% end -%>
 <% end -%>
     Satisfy Any
   </Limit>


### PR DESCRIPTION
Some parameters spelled in plural could be mistakenly set to an array
which wont work with ruby 1.9 when used in an ERB template.
