### PR TITLE
Rename apache to apache c2c

### DIFF
--- a/manifests/administration.pp
+++ b/manifests/administration.pp
@@ -1,11 +1,11 @@
-class apache::administration (
+class apache_c2c::administration (
   $sudo_user = $sudo_apache_admin_user,
 ) {
 
-  include ::apache::params
+  include ::apache_c2c::params
 
   $distro_specific_apache_sudo = $::osfamily ? {
-    'RedHat' => "/usr/sbin/apachectl, /sbin/service ${apache::params::pkg}",
+    'RedHat' => "/usr/sbin/apachectl, /sbin/service ${apache_c2c::params::pkg}",
     'Debian' => '/usr/sbin/apache2ctl',
   }
 
@@ -15,8 +15,8 @@ class apache::administration (
   }
 
   # used in erb template
-  $wwwpkgname = $apache::params::pkg
-  $wwwuser    = $apache::params::user
+  $wwwpkgname = $apache_c2c::params::pkg
+  $wwwuser    = $apache_c2c::params::user
 
   $sudo_group = '%apache-admin'
   $sudo_user_alias = flatten([$sudo_group, $sudo_user])

--- a/manifests/auth/basic/file/group.pp
+++ b/manifests/auth/basic/file/group.pp
@@ -1,4 +1,4 @@
-define apache::auth::basic::file::group(
+define apache_c2c::auth::basic::file::group(
   $vhost,
   $groups,
   $ensure        = 'present',
@@ -10,15 +10,15 @@ define apache::auth::basic::file::group(
 
   validate_string($groups)
 
-  $wwwroot = $apache::root
+  $wwwroot = $apache_c2c::root
   validate_absolute_path($wwwroot)
 
   $fname = regsubst($name, '\s', '_', 'G')
 
-  include apache::params
+  include apache_c2c::params
 
-  if defined(Apache::Module['authn_file']) {} else {
-    apache::module {'authn_file': }
+  if defined(Apache_c2c::Module['authn_file']) {} else {
+    apache_c2c::module {'authn_file': }
   }
 
   if $authUserFile {

--- a/manifests/auth/basic/file/user.pp
+++ b/manifests/auth/basic/file/user.pp
@@ -1,4 +1,4 @@
-define apache::auth::basic::file::user(
+define apache_c2c::auth::basic::file::user(
   $vhost,
   $ensure       = 'present',
   $authname     = false,
@@ -11,11 +11,11 @@ define apache::auth::basic::file::user(
 
   $fname = regsubst($name, '\s', '_', 'G')
 
-  $wwwroot = $apache::root
+  $wwwroot = $apache_c2c::root
   validate_absolute_path($wwwroot)
 
-  if !defined(Apache::Module['authn_file']) {
-    apache::module {'authn_file': }
+  if !defined(Apache_c2c::Module['authn_file']) {
+    apache_c2c::module {'authn_file': }
   }
 
   if $authUserFile {

--- a/manifests/auth/basic/file/webdav/user.pp
+++ b/manifests/auth/basic/file/webdav/user.pp
@@ -1,4 +1,4 @@
-define apache::auth::basic::file::webdav::user (
+define apache_c2c::auth::basic::file::webdav::user (
   $vhost,
   $ensure=present,
   $authname=false,
@@ -17,11 +17,11 @@ define apache::auth::basic::file::webdav::user (
 
   $fname = regsubst($name, '\s', '_', 'G')
 
-  $wwwroot = $apache::root
+  $wwwroot = $apache_c2c::root
   validate_absolute_path($wwwroot)
 
-  if !defined(Apache::Module['authn_file']) {
-    apache::module {'authn_file': }
+  if !defined(Apache_c2c::Module['authn_file']) {
+    apache_c2c::module {'authn_file': }
   }
 
   if $authUserFile {

--- a/manifests/auth/basic/ldap.pp
+++ b/manifests/auth/basic/ldap.pp
@@ -1,4 +1,4 @@
-define apache::auth::basic::ldap(
+define apache_c2c::auth::basic::ldap(
   $vhost,
   $authLDAPUrl,
   $ensure='present',
@@ -19,15 +19,15 @@ define apache::auth::basic::ldap(
 
   $fname = regsubst($name, '\s', '_', 'G')
 
-  $wwwroot = $apache::root
+  $wwwroot = $apache_c2c::root
   validate_absolute_path($wwwroot)
 
-  if defined(Apache::Module['ldap']) {} else {
-    apache::module {'ldap': }
+  if defined(Apache_c2c::Module['ldap']) {} else {
+    apache_c2c::module {'ldap': }
   }
 
-  if defined(Apache::Module['authnz_ldap']) {} else {
-    apache::module {'authnz_ldap': }
+  if defined(Apache_c2c::Module['authnz_ldap']) {} else {
+    apache_c2c::module {'authnz_ldap': }
   }
 
   if $authname {

--- a/manifests/auth/htgroup.pp
+++ b/manifests/auth/htgroup.pp
@@ -1,4 +1,4 @@
-define apache::auth::htgroup(
+define apache_c2c::auth::htgroup(
   $groupname,
   $members,
   $ensure            = 'present',
@@ -7,9 +7,9 @@ define apache::auth::htgroup(
   $groupFileName     = 'htgroup',
 ) {
 
-  include apache::params
+  include apache_c2c::params
 
-  $wwwroot = $apache::root
+  $wwwroot = $apache_c2c::root
   validate_absolute_path($wwwroot)
 
   if $groupFileLocation {

--- a/manifests/auth/htpasswd.pp
+++ b/manifests/auth/htpasswd.pp
@@ -1,4 +1,4 @@
-define apache::auth::htpasswd (
+define apache_c2c::auth::htpasswd (
   $username,
   $ensure           = 'present',
   $vhost            = false,
@@ -8,7 +8,7 @@ define apache::auth::htpasswd (
   $clearPassword    = false,
 ) {
 
-  $wwwroot = $apache::root
+  $wwwroot = $apache_c2c::root
   validate_absolute_path($wwwroot)
 
   if $userFileLocation {

--- a/manifests/aw-stats.pp
+++ b/manifests/aw-stats.pp
@@ -1,9 +1,9 @@
 # about $allowfullyearview, refer to templates/awstats.erb in this module for
 # a detailed explanation an possible values.
-define apache::aw-stats($ensure=present, $aliases=[], $allowfullyearview=2) {
+define apache_c2c::aw-stats($ensure=present, $aliases=[], $allowfullyearview=2) {
 
   # used in ERB template
-  $wwwroot = $apache::root
+  $wwwroot = $apache_c2c::root
   validate_absolute_path($wwwroot)
 
   file { "/etc/awstats/awstats.${name}.conf":
@@ -28,6 +28,6 @@ define apache::aw-stats($ensure=present, $aliases=[], $allowfullyearview=2) {
     source  => $source,
     seltype => $seltype,
     notify  => Exec['apache-graceful'],
-    require => Apache::Vhost[$name],
+    require => Apache_c2c::Vhost[$name],
   }
 }

--- a/manifests/awstats.pp
+++ b/manifests/awstats.pp
@@ -1,4 +1,4 @@
-class apache::awstats {
+class apache_c2c::awstats {
 
   package { 'awstats':
     ensure => installed

--- a/manifests/balancer.pp
+++ b/manifests/balancer.pp
@@ -29,11 +29,11 @@
 #
 # Requires:
 # - Class["apache"]
-# - matching Apache::Vhost[] instance
+# - matching Apache_c2c::Vhost[] instance
 #
 # Example usage:
 #
-#   apache::balancer { "my balanced service":
+#   apache_c2c::balancer { "my balanced service":
 #     location   => "/mywebapp/",
 #     proto      => "ajp",
 #     members    => [
@@ -46,7 +46,7 @@
 #     vhost      => "www.example.com",
 #   }
 #
-define apache::balancer (
+define apache_c2c::balancer (
   $vhost,
   $ensure='present',
   $location='',
@@ -61,19 +61,19 @@ define apache::balancer (
   # normalise name
   $fname = regsubst($name, '\s', '_', 'G')
 
-  $wwwroot = $apache::root
+  $wwwroot = $apache_c2c::root
   validate_absolute_path($wwwroot)
 
   $balancer = "balancer://${fname}"
 
-  if !defined(Apache::Module['proxy']) {
-    apache::module {'proxy':
+  if !defined(Apache_c2c::Module['proxy']) {
+    apache_c2c::module {'proxy':
       ensure => $ensure,
     }
   }
 
-  if !defined(Apache::Module['proxy_balancer']) {
-    apache::module {'proxy_balancer':
+  if !defined(Apache_c2c::Module['proxy_balancer']) {
+    apache_c2c::module {'proxy_balancer':
       ensure => $ensure,
     }
   }
@@ -81,16 +81,16 @@ define apache::balancer (
   # ensure proxy modules are enabled
   case $proto {
     http: {
-      if !defined(Apache::Module['proxy_http']) {
-        apache::module {'proxy_http':
+      if !defined(Apache_c2c::Module['proxy_http']) {
+        apache_c2c::module {'proxy_http':
           ensure => $ensure,
         }
       }
     }
 
     ajp: {
-      if !defined(Apache::Module['proxy_ajp']) {
-        apache::module {'proxy_ajp':
+      if !defined(Apache_c2c::Module['proxy_ajp']) {
+        apache_c2c::module {'proxy_ajp':
           ensure => $ensure,
         }
       }
@@ -121,6 +121,6 @@ define apache::balancer (
     seltype => $seltype,
     path    => $path,
     notify  => Exec['apache-graceful'],
-    require => Apache::Vhost[$vhost],
+    require => Apache_c2c::Vhost[$vhost],
   }
 }

--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -4,24 +4,24 @@
 #
 # It shouldn't be necessary to directly include this class.
 #
-class apache::base {
+class apache_c2c::base {
 
-  include apache::params
-  $wwwroot = $apache::root
+  include apache_c2c::params
+  $wwwroot = $apache_c2c::root
   validate_absolute_path($wwwroot)
 
   include concat::setup
 
-  $access_log = $apache::params::access_log
-  $error_log  = $apache::params::error_log
+  $access_log = $apache_c2c::params::access_log
+  $error_log  = $apache_c2c::params::error_log
 
-  concat {"${apache::params::conf}/ports.conf":
+  concat {"${apache_c2c::params::conf}/ports.conf":
     notify  => Service['apache'],
     require => Package['apache'],
   }
 
   # removed this folder originally created by common::concatfilepart
-  file {"${apache::params::conf}/ports.conf.d":
+  file {"${apache_c2c::params::conf}/ports.conf.d":
     ensure  => absent,
     purge   => true,
     recurse => true,
@@ -39,7 +39,7 @@ class apache::base {
 
   file {'log directory':
     ensure  => directory,
-    path    => $apache::params::log,
+    path    => $apache_c2c::params::log,
     mode    => '0755',
     owner   => 'root',
     group   => 'root',
@@ -48,30 +48,30 @@ class apache::base {
 
   user { 'apache user':
     ensure  => present,
-    name    => $apache::params::user,
+    name    => $apache_c2c::params::user,
     require => Package['apache'],
     shell   => '/bin/sh',
   }
 
   group { 'apache group':
     ensure  => present,
-    name    => $apache::params::user,
+    name    => $apache_c2c::params::user,
     require => Package['apache'],
   }
 
   package { 'apache':
     ensure => installed,
-    name   => $apache::params::pkg,
+    name   => $apache_c2c::params::pkg,
   }
 
-  $service_ensure = $apache::service_ensure ? {
+  $service_ensure = $apache_c2c::service_ensure ? {
     'unmanaged' => undef,
-    default     => $apache::service_ensure,
+    default     => $apache_c2c::service_ensure,
   }
   service { 'apache':
     ensure     => $service_ensure,
-    name       => $apache::params::pkg,
-    enable     => $apache::service_enable,
+    name       => $apache_c2c::params::pkg,
+    enable     => $apache_c2c::service_enable,
     hasrestart => true,
     require    => Package['apache'],
   }
@@ -86,14 +86,14 @@ class apache::base {
     require => Package['apache'],
   }
 
-  if ! $apache::disable_port80 {
+  if ! $apache_c2c::disable_port80 {
 
-    apache::listen { '80': ensure => present }
-    apache::namevhost { '*:80': ensure => present }
+    apache_c2c::listen { '80': ensure => present }
+    apache_c2c::namevhost { '*:80': ensure => present }
 
   }
 
-  apache::module {['alias', 'auth_basic', 'authn_file', 'authz_default',
+  apache_c2c::module {['alias', 'auth_basic', 'authn_file', 'authz_default',
   'authz_groupfile', 'authz_host', 'authz_user', 'autoindex', 'dir', 'env',
   'mime', 'negotiation', 'rewrite', 'setenvif', 'status', 'cgi']:
     ensure => present,
@@ -112,26 +112,26 @@ class apache::base {
 
   file {'default virtualhost':
     ensure  => present,
-    path    => "${apache::params::conf}/sites-available/default-vhost",
+    path    => "${apache_c2c::params::conf}/sites-available/default-vhost",
     content => template("${module_name}/default-vhost.erb"),
     require => Package['apache'],
     notify  => Exec['apache-graceful'],
-    before  => File["${apache::params::conf}/sites-enabled/000-default-vhost"],
+    before  => File["${apache_c2c::params::conf}/sites-enabled/000-default-vhost"],
     mode    => '0644',
   }
 
   if $apache_disable_default_vhost {
 
-    file { "${apache::params::conf}/sites-enabled/000-default-vhost":
+    file { "${apache_c2c::params::conf}/sites-enabled/000-default-vhost":
       ensure => absent,
       notify => Exec['apache-graceful'],
     }
 
   } else {
 
-    file { "${apache::params::conf}/sites-enabled/000-default-vhost":
+    file { "${apache_c2c::params::conf}/sites-enabled/000-default-vhost":
       ensure => link,
-      target => "${apache::params::conf}/sites-available/default-vhost",
+      target => "${apache_c2c::params::conf}/sites-available/default-vhost",
       notify => Exec['apache-graceful'],
     }
 
@@ -155,9 +155,9 @@ class apache::base {
     source => "puppet:///modules/${module_name}/usr/local/bin/htgroup",
   }
 
-  file { ["${apache::params::conf}/sites-enabled/default",
-          "${apache::params::conf}/sites-enabled/000-default",
-          "${apache::params::conf}/sites-enabled/default-ssl"]:
+  file { ["${apache_c2c::params::conf}/sites-enabled/default",
+          "${apache_c2c::params::conf}/sites-enabled/000-default",
+          "${apache_c2c::params::conf}/sites-enabled/default-ssl"]:
     ensure => absent,
     notify => Exec['apache-graceful'],
   }

--- a/manifests/base/ssl.pp
+++ b/manifests/base/ssl.pp
@@ -4,12 +4,12 @@
 #
 # It shouldn't be necessary to directly include this class.
 #
-class apache::base::ssl {
+class apache_c2c::base::ssl {
 
-  if ! $apache::ssl::disable_port443 {
+  if ! $apache_c2c::ssl::disable_port443 {
 
-    apache::listen { '443': ensure => present }
-    apache::namevhost { '*:443': ensure => present }
+    apache_c2c::listen { '443': ensure => present }
+    apache_c2c::namevhost { '*:443': ensure => present }
 
   }
 

--- a/manifests/collectd.pp
+++ b/manifests/collectd.pp
@@ -13,9 +13,9 @@
 # Usage:
 #   include apache
 #   include collectd
-#   include apache::collectd
+#   include apache_c2c::collectd
 #
-class apache::collectd {
+class apache_c2c::collectd {
 
   # trick to check which collectd module we are using
   include ::collectd

--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -19,13 +19,13 @@
 #
 # Example usage:
 #
-#   apache::conf { "example 1":
+#   apache_c2c::conf { "example 1":
 #     ensure        => present,
 #     path          => /var/www/foo/conf
 #     configuration => "WSGIPythonEggs /var/cache/python-eggs",
 #   }
 #
-define apache::conf(
+define apache_c2c::conf(
   $configuration,
   $path,
   $ensure   = present,

--- a/manifests/confd.pp
+++ b/manifests/confd.pp
@@ -1,7 +1,7 @@
 # == Definition: apache::confd
 #
 # Convenient wrapper around apache::conf definition to put configuration
-# snippets in ${apache::params::conf}/conf.d directory
+# snippets in ${apache_c2c::params::conf}/conf.d directory
 #
 # Parameters:
 # - *ensure*: present/absent.
@@ -15,20 +15,20 @@
 #
 # Example usage:
 #
-#   apache::confd { "example 1":
+#   apache_c2c::confd { "example 1":
 #     ensure        => present,
 #     configuration => "WSGIPythonEggs /var/cache/python-eggs",
 #   }
 #
-define apache::confd(
+define apache_c2c::confd(
   $configuration,
   $ensure        = present,
   $filename      = '',
 ) {
-  include apache::params
-  apache::conf {$name:
+  include apache_c2c::params
+  apache_c2c::conf {$name:
     ensure        => $ensure,
-    path          => "${apache::params::conf}/conf.d",
+    path          => "${apache_c2c::params::conf}/conf.d",
     filename      => $filename,
     configuration => $configuration,
     notify        => Service['apache'],

--- a/manifests/debian.pp
+++ b/manifests/debian.pp
@@ -1,7 +1,7 @@
-class apache::debian inherits apache::base {
+class apache_c2c::debian inherits apache_c2c::base {
 
-  include apache::params
-  $wwwroot = $apache::root
+  include apache_c2c::params
+  $wwwroot = $apache_c2c::root
   validate_absolute_path($wwwroot)
 
   # BEGIN inheritance from apache::base
@@ -11,7 +11,7 @@ class apache::debian inherits apache::base {
   }
 
   # the following variables are used in template logrotate-httpd.erb
-  $logrotate_paths = "${wwwroot}/*/logs/*.log ${apache::params::log}/*log"
+  $logrotate_paths = "${wwwroot}/*/logs/*.log ${apache_c2c::params::log}/*log"
   $httpd_pid_file = '/var/run/apache2.pid'
   $httpd_reload_cmd = '/etc/init.d/apache2 restart > /dev/null'
   $awstats_condition = '-f /usr/share/doc/awstats/examples/awstats_updateall.pl -a -f /usr/lib/cgi-bin/awstats.pl'
@@ -22,7 +22,7 @@ class apache::debian inherits apache::base {
   }
 
   File['default status module configuration'] {
-    path   => "${apache::params::conf}/mods-available/status.conf",
+    path   => "${apache_c2c::params::conf}/mods-available/status.conf",
     source => "puppet:///modules/${module_name}/etc/apache2/mods-available/status.conf",
   }
   # END inheritance from apache::base
@@ -55,7 +55,7 @@ class apache::debian inherits apache::base {
     content => "<html><body><h1>It works!</h1></body></html>\n",
   }
 
-  file { "${apache::params::conf}/conf.d/servername.conf":
+  file { "${apache_c2c::params::conf}/conf.d/servername.conf":
     content => "ServerName ${::fqdn}\n",
     notify  => Service['apache'],
     require => Package['apache'],

--- a/manifests/deflate.pp
+++ b/manifests/deflate.pp
@@ -1,14 +1,14 @@
-class apache::deflate {
+class apache_c2c::deflate {
 
-  include apache::params
+  include apache_c2c::params
 
-  apache::module {'deflate':
+  apache_c2c::module {'deflate':
     ensure => present,
   }
 
   file { 'deflate.conf':
     ensure  => present,
-    path    => "${apache::params::conf}/conf.d/deflate.conf",
+    path    => "${apache_c2c::params::conf}/conf.d/deflate.conf",
     content => '# file managed by puppet
 <IfModule mod_deflate.c>
   AddOutputFilterByType DEFLATE application/x-javascript application/javascript text/css

--- a/manifests/dev.pp
+++ b/manifests/dev.pp
@@ -6,9 +6,9 @@
 #
 # Example usage:
 #
-#   include apache::dev
+#   include apache_c2c::dev
 #
-class apache::dev {
+class apache_c2c::dev {
   $pkg_name = $::operatingsystem ? {
     /RedHat|CentOS/ => 'httpd-devel',
     /Debian|Ubuntu/ => 'apache2-threaded-dev',

--- a/manifests/directive.pp
+++ b/manifests/directive.pp
@@ -14,11 +14,11 @@
 #
 # Requires:
 # - Class["apache"]
-# - matching Apache::Vhost[] instance
+# - matching Apache_c2c::Vhost[] instance
 #
 # Example usage:
 #
-#   apache::directive { "example 1":
+#   apache_c2c::directive { "example 1":
 #     ensure    => present,
 #     directive => "
 #       RewriteEngine on
@@ -27,32 +27,32 @@
 #     vhost     => "www.example.com",
 #   }
 #
-#   apache::directive { "example 2":
+#   apache_c2c::directive { "example 2":
 #     ensure    => present,
 #     directive => content("example/snippet.erb"),
 #     vhost     => "www.example.com",
 #   }
 #
-define apache::directive(
+define apache_c2c::directive(
   $vhost,
   $ensure    = 'present',
   $directive = '',
   $filename  = '',
 ) {
 
-  $wwwroot = $apache::root
+  $wwwroot = $apache_c2c::root
   validate_absolute_path($wwwroot)
 
   if ($ensure == 'present' and $directive == '') {
     fail 'empty "directive" parameter'
   }
 
-  apache::conf {$name:
+  apache_c2c::conf {$name:
     ensure        => $ensure,
     path          => "${wwwroot}/${vhost}/conf",
     prefix        => 'directive',
     filename      => $filename,
     configuration => $directive,
-    require       => Apache::Vhost[$vhost],
+    require       => Apache_c2c::Vhost[$vhost],
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,7 +1,7 @@
 # = Class: apache
 #
 # Installs apache, ensures a few useful modules are installed (see
-# apache::base), ensures that the service is running and the logs get rotated.
+# apache_c2c::base), ensures that the service is running and the logs get rotated.
 #
 # By including subclasses where distro specific stuff is handled, it ensure that
 # the apache class behaves the same way on diffrent distributions.
@@ -27,12 +27,12 @@
 #
 #   include apache
 #
-class apache (
-  $root            = $apache::params::root,
+class apache_c2c (
+  $root            = $apache_c2c::params::root,
   $service_ensure  = 'running',
   $service_enable  = true,
   $disable_port80  = false,
-) inherits ::apache::params {
+) inherits ::apache_c2c::params {
 
   validate_absolute_path ($root)
   validate_re ($service_ensure, 'running|stopped|unmanaged')
@@ -40,8 +40,8 @@ class apache (
   validate_bool ($disable_port80)
 
   case $::operatingsystem {
-    Debian,Ubuntu:  { include apache::debian}
-    RedHat,CentOS:  { include apache::redhat}
+    Debian,Ubuntu:  { include apache_c2c::debian}
+    RedHat,CentOS:  { include apache_c2c::redhat}
     default: { fail "Unsupported operatingsystem ${::operatingsystem}" }
   }
 }

--- a/manifests/listen.pp
+++ b/manifests/listen.pp
@@ -11,16 +11,16 @@
 #
 # Example usage:
 #
-#   apache::listen { "80": }
-#   apache::listen { "127.0.0.1:8080": ensure => present }
+#   apache_c2c::listen { "80": }
+#   apache_c2c::listen { "127.0.0.1:8080": ensure => present }
 #
-define apache::listen ($ensure='present') {
+define apache_c2c::listen ($ensure='present') {
 
-  include apache::params
+  include apache_c2c::params
 
   concat::fragment { "apache-ports.conf-${name}":
     ensure  => $ensure,
-    target  => "${apache::params::conf}/ports.conf",
+    target  => "${apache_c2c::params::conf}/ports.conf",
     content => "Listen ${name}\n",
   }
 

--- a/manifests/module.pp
+++ b/manifests/module.pp
@@ -1,6 +1,6 @@
-define apache::module ($ensure='present') {
+define apache_c2c::module ($ensure='present') {
 
-  include apache::params
+  include apache_c2c::params
 
   $a2enmod_deps = $::operatingsystem ? {
     /RedHat|CentOS/ => [
@@ -14,7 +14,7 @@ define apache::module ($ensure='present') {
   }
 
   if $::selinux == 'true' and $ensure == 'present' {
-    apache::redhat::selinux {$name: }
+    apache_c2c::redhat::selinux {$name: }
   }
 
   $commands_path = $::osfamily ? {
@@ -26,8 +26,8 @@ define apache::module ($ensure='present') {
     'present' : {
       exec { "a2enmod ${name}":
         command => "${commands_path}/a2enmod ${name}",
-        unless  => "/bin/sh -c '[ -L ${apache::params::conf}/mods-enabled/${name}.load ] \\
-          && [ ${apache::params::conf}/mods-enabled/${name}.load -ef ${apache::params::conf}/mods-available/${name}.load ]'",
+        unless  => "/bin/sh -c '[ -L ${apache_c2c::params::conf}/mods-enabled/${name}.load ] \\
+          && [ ${apache_c2c::params::conf}/mods-enabled/${name}.load -ef ${apache_c2c::params::conf}/mods-available/${name}.load ]'",
         require => $a2enmod_deps,
         notify  => Service['apache'],
       }
@@ -36,8 +36,8 @@ define apache::module ($ensure='present') {
     'absent': {
       exec { "a2dismod ${name}":
         command => "${commands_path}/a2dismod ${name}",
-        onlyif  => "/bin/sh -c '[ -L ${apache::params::conf}/mods-enabled/${name}.load ] \\
-          || [ -e ${apache::params::conf}/mods-enabled/${name}.load ]'",
+        onlyif  => "/bin/sh -c '[ -L ${apache_c2c::params::conf}/mods-enabled/${name}.load ] \\
+          || [ -e ${apache_c2c::params::conf}/mods-enabled/${name}.load ]'",
         require => $a2enmod_deps,
         notify  => Service['apache'],
       }

--- a/manifests/namevhost.pp
+++ b/manifests/namevhost.pp
@@ -2,7 +2,7 @@
 #
 # Adds a "NameVirtualHost" directive to apache's port.conf file.
 #
-# Every "ports" parameter you define Apache::Vhost resources should have a
+# Every "ports" parameter you define Apache_c2c::Vhost resources should have a
 # matching NameVirtualHost directive.
 #
 # Parameters:
@@ -14,16 +14,16 @@
 #
 # Example usage:
 #
-#   apache::namevhost { "*:80": }
-#   apache::namevhost { "127.0.0.1:8080": ensure => present }
+#   apache_c2c::namevhost { "*:80": }
+#   apache_c2c::namevhost { "127.0.0.1:8080": ensure => present }
 #
-define apache::namevhost ($ensure='present') {
+define apache_c2c::namevhost ($ensure='present') {
 
-  include apache::params
+  include apache_c2c::params
 
   concat::fragment { "apache-namevhost.conf-${name}":
     ensure  => $ensure,
-    target  => "${apache::params::conf}/ports.conf",
+    target  => "${apache_c2c::params::conf}/ports.conf",
     content => "NameVirtualHost ${name}\n",
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,4 +1,4 @@
-class apache::params {
+class apache_c2c::params {
 
   $pkg = $::operatingsystem ? {
     /RedHat|CentOS/ => 'httpd',

--- a/manifests/proxypass.pp
+++ b/manifests/proxypass.pp
@@ -20,11 +20,11 @@
 #
 # Requires:
 # - Class["apache"]
-# - matching Apache::Vhost[] instance
+# - matching Apache_c2c::Vhost[] instance
 #
 # Example usage:
 #
-#   apache::proxypass { "proxy legacy dir to legacy server":
+#   apache_c2c::proxypass { "proxy legacy dir to legacy server":
 #     ensure   => present,
 #     location => "/legacy/",
 #     url      => "http://legacyserver.example.com",
@@ -32,7 +32,7 @@
 #     vhost    => "www.example.com",
 #   }
 #
-define apache::proxypass (
+define apache_c2c::proxypass (
   $vhost,
   $ensure='present',
   $location='',
@@ -43,16 +43,16 @@ define apache::proxypass (
 
   $fname = regsubst($name, '\s', '_', 'G')
 
-  $wwwroot = $apache::root
+  $wwwroot = $apache_c2c::root
   validate_absolute_path($wwwroot)
 
-  if defined(Apache::Module['proxy']) {} else {
-    apache::module {'proxy':
+  if defined(Apache_c2c::Module['proxy']) {} else {
+    apache_c2c::module {'proxy':
     }
   }
 
-  if defined(Apache::Module['proxy_http']) {} else {
-    apache::module {'proxy_http':
+  if defined(Apache_c2c::Module['proxy_http']) {} else {
+    apache_c2c::module {'proxy_http':
     }
   }
 
@@ -71,6 +71,6 @@ define apache::proxypass (
     seltype => $seltype,
     path    => $path,
     notify  => Exec['apache-graceful'],
-    require => Apache::Vhost[$vhost],
+    require => Apache_c2c::Vhost[$vhost],
   }
 }

--- a/manifests/redhat.pp
+++ b/manifests/redhat.pp
@@ -1,7 +1,7 @@
-class apache::redhat inherits apache::base {
+class apache_c2c::redhat inherits apache_c2c::base {
 
-  include apache::params
-  $wwwroot = $apache::root
+  include apache_c2c::params
+  $wwwroot = $apache_c2c::root
   validate_absolute_path($wwwroot)
 
   # BEGIN inheritance from apache::base
@@ -20,7 +20,7 @@ class apache::redhat inherits apache::base {
   }
 
   # the following variables are used in template logrotate-httpd.erb
-  $logrotate_paths = "${wwwroot}/*/logs/*.log ${apache::params::log}/*log"
+  $logrotate_paths = "${wwwroot}/*/logs/*.log ${apache_c2c::params::log}/*log"
   $httpd_pid_file = $::lsbmajdistrelease ? {
     /4|5/   => '/var/run/httpd.pid',
     default => '/var/run/httpd/httpd.pid',
@@ -34,7 +34,7 @@ class apache::redhat inherits apache::base {
   }
 
   File['default status module configuration'] {
-    path   => "${apache::params::conf}/conf.d/status.conf",
+    path   => "${apache_c2c::params::conf}/conf.d/status.conf",
     source => "puppet:///modules/${module_name}/etc/httpd/conf/status.conf",
   }
 
@@ -70,9 +70,9 @@ class apache::redhat inherits apache::base {
   }
 
   file { [
-      "${apache::params::conf}/sites-available",
-      "${apache::params::conf}/sites-enabled",
-      "${apache::params::conf}/mods-enabled"
+      "${apache_c2c::params::conf}/sites-available",
+      "${apache_c2c::params::conf}/sites-enabled",
+      "${apache_c2c::params::conf}/mods-enabled"
     ]:
     ensure  => directory,
     mode    => '0755',
@@ -82,7 +82,7 @@ class apache::redhat inherits apache::base {
     require => Package['apache'],
   }
 
-  file { "${apache::params::conf}/conf/httpd.conf":
+  file { "${apache_c2c::params::conf}/conf/httpd.conf":
     ensure  => present,
     content => template("${module_name}/httpd.conf.erb"),
     seltype => 'httpd_config_t',
@@ -98,7 +98,7 @@ class apache::redhat inherits apache::base {
     5 => "puppet:///modules/${module_name}/etc/httpd/mods-available/redhat5/",
     6 => "puppet:///modules/${module_name}/etc/httpd/mods-available/redhat6/",
   }
-  file { "${apache::params::conf}/mods-available":
+  file { "${apache_c2c::params::conf}/mods-available":
     ensure  => directory,
     source  => $source,
     recurse => true,
@@ -110,7 +110,7 @@ class apache::redhat inherits apache::base {
   }
 
   # this module is statically compiled on debian and must be enabled here
-  apache::module {'log_config':
+  apache_c2c::module {'log_config':
     ensure => present,
     notify => Exec['apache-graceful'],
   }
@@ -124,7 +124,7 @@ class apache::redhat inherits apache::base {
 
   # no idea why redhat choose to put this file there. apache fails if it's
   # present and mod_proxy isn't...
-  file { "${apache::params::conf}/conf.d/proxy_ajp.conf":
+  file { "${apache_c2c::params::conf}/conf.d/proxy_ajp.conf":
     ensure  => present,
     content => "# File managed by puppet
 #

--- a/manifests/redhat/selinux.pp
+++ b/manifests/redhat/selinux.pp
@@ -1,4 +1,4 @@
-define apache::redhat::selinux {
+define apache_c2c::redhat::selinux {
 
   case $name {
 

--- a/manifests/redirectmatch.pp
+++ b/manifests/redirectmatch.pp
@@ -14,17 +14,17 @@
 #
 # Requires:
 # - Class["apache"]
-# - matching Apache::Vhost[] instance
+# - matching Apache_c2c::Vhost[] instance
 #
 # Example usage:
 #
-#   apache::redirectmatch { "example":
+#   apache_c2c::redirectmatch { "example":
 #     regex => "^/(foo|bar)",
 #     url   => "http://foobar.example.com/",
 #     vhost => "www.example.com",
 #   }
 #
-define apache::redirectmatch (
+define apache_c2c::redirectmatch (
   $regex,
   $url,
   $vhost,
@@ -34,7 +34,7 @@ define apache::redirectmatch (
 
   $fname = regsubst($name, '\s', '_', 'G')
 
-  $wwwroot = $apache::root
+  $wwwroot = $apache_c2c::root
   validate_absolute_path($wwwroot)
 
   $seltype = $::operatingsystem ? {
@@ -52,6 +52,6 @@ define apache::redirectmatch (
     seltype => $seltype,
     path    => $path,
     notify  => Exec['apache-graceful'],
-    require => Apache::Vhost[$vhost],
+    require => Apache_c2c::Vhost[$vhost],
   }
 }

--- a/manifests/reverseproxy.pp
+++ b/manifests/reverseproxy.pp
@@ -1,12 +1,12 @@
-class apache::reverseproxy {
+class apache_c2c::reverseproxy {
 
-  include apache::params
+  include apache_c2c::params
 
-  apache::module {['proxy', 'proxy_http', 'proxy_ajp', 'proxy_connect']: }
+  apache_c2c::module {['proxy', 'proxy_http', 'proxy_ajp', 'proxy_connect']: }
 
   file { 'reverseproxy.conf':
     ensure  => 'present',
-    path    => "${apache::params::conf}/conf.d/reverseproxy.conf",
+    path    => "${apache_c2c::params::conf}/conf.d/reverseproxy.conf",
     content => '# file managed by puppet
 <IfModule mod_proxy.c>
   ProxyRequests Off

--- a/manifests/security.pp
+++ b/manifests/security.pp
@@ -1,4 +1,4 @@
-class apache::security {
+class apache_c2c::security {
 
   case $::osfamily {
 
@@ -33,7 +33,7 @@ class apache::security {
     }
   }
 
-  apache::module { ['unique_id', 'security']:
+  apache_c2c::module { ['unique_id', 'security']:
     ensure  => present,
     require => Package['apache-mod_security'],
   }

--- a/manifests/ssl.pp
+++ b/manifests/ssl.pp
@@ -54,15 +54,15 @@
 #
 # == Example ==
 #
-#  include apache::ssl
+#  include apache_c2c::ssl
 #
-class apache::ssl (
-  $root            = $apache::params::root,
+class apache_c2c::ssl (
+  $root            = $apache_c2c::params::root,
   $service_ensure  = 'running',
   $service_enable  = true,
   $disable_port80  = false,
   $disable_port443 = false,
-) inherits ::apache::params {
+) inherits ::apache_c2c::params {
 
   validate_absolute_path ($root)
   validate_re ($service_ensure, 'running|stopped|unmanaged')
@@ -70,7 +70,7 @@ class apache::ssl (
   validate_bool ($disable_port80)
   validate_bool ($disable_port443)
 
-  class { '::apache':
+  class { '::apache_c2c':
     root           => $root,
     service_ensure => $service_ensure,
     service_enable => $service_enable,
@@ -78,8 +78,8 @@ class apache::ssl (
   }
 
   case $::operatingsystem {
-    Debian,Ubuntu:  { include apache::ssl::debian}
-    RedHat,CentOS:  { include apache::ssl::redhat}
+    Debian,Ubuntu:  { include apache_c2c::ssl::debian}
+    RedHat,CentOS:  { include apache_c2c::ssl::redhat}
     default: { fail "Unsupported operatingsystem ${::operatingsystem}" }
   }
 }

--- a/manifests/ssl/debian.pp
+++ b/manifests/ssl/debian.pp
@@ -1,6 +1,6 @@
-class apache::ssl::debian inherits apache::base::ssl {
+class apache_c2c::ssl::debian inherits apache_c2c::base::ssl {
 
-  apache::module {'ssl':
+  apache_c2c::module {'ssl':
     ensure => present,
   }
 

--- a/manifests/ssl/redhat.pp
+++ b/manifests/ssl/redhat.pp
@@ -1,4 +1,4 @@
-class apache::ssl::redhat inherits apache::base::ssl {
+class apache_c2c::ssl::redhat inherits apache_c2c::base::ssl {
 
   package {'mod_ssl':
     ensure => installed,
@@ -17,7 +17,7 @@ class apache::ssl::redhat inherits apache::base::ssl {
     before  => Exec['apache-graceful'],
   }
 
-  apache::module { 'ssl':
+  apache_c2c::module { 'ssl':
     ensure  => present,
     require => File['/etc/httpd/conf.d/ssl.conf'],
     notify  => Service['apache'],

--- a/manifests/svnserver.pp
+++ b/manifests/svnserver.pp
@@ -1,4 +1,4 @@
-class apache::svnserver inherits apache::ssl {
+class apache_c2c::svnserver inherits apache_c2c::ssl {
 
   case $::operatingsystem {
 
@@ -21,7 +21,7 @@ class apache::svnserver inherits apache::ssl {
     ensure => present,
   }
 
-  apache::module {
+  apache_c2c::module {
     [
       'dav',
       'dav_svn',

--- a/manifests/userdir.pp
+++ b/manifests/userdir.pp
@@ -1,4 +1,4 @@
-class apache::userdir {
+class apache_c2c::userdir {
 
   file {'/etc/skel/public_html':
     ensure => directory,
@@ -30,7 +30,7 @@ class apache::userdir {
     source  => "puppet:///modules/${module_name}/README_userdir",
   }
 
-  apache::module { 'userdir':
+  apache_c2c::module { 'userdir':
     ensure => present,
   }
 

--- a/manifests/userdirinstance.pp
+++ b/manifests/userdirinstance.pp
@@ -1,9 +1,9 @@
-define apache::userdirinstance(
+define apache_c2c::userdirinstance(
   $vhost,
   $ensure = present,
 ) {
 
-  $wwwroot = $apache::root
+  $wwwroot = $apache_c2c::root
   validate_absolute_path($wwwroot)
 
   $seltype = $::operatingsystem ? {

--- a/manifests/vhost-ssl.pp
+++ b/manifests/vhost-ssl.pp
@@ -6,7 +6,7 @@
 # The definition now wraps around apache::vhost::ssl
 # for backward compatibility reasons.
 
-define apache::vhost-ssl (
+define apache_c2c::vhost-ssl (
   $ensure=present,
   $config_file='',
   $config_content=false,

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -1,4 +1,4 @@
-define apache::vhost (
+define apache_c2c::vhost (
   $ensure=present,
   $config_file='',
   $config_content=false,
@@ -18,20 +18,20 @@ define apache::vhost (
   $accesslog_format='combined',
 ) {
 
-  include ::apache::params
+  include ::apache_c2c::params
 
   $wwwuser = $user ? {
-    ''      => $apache::params::user,
+    ''      => $apache_c2c::params::user,
     default => $user,
   }
 
   $wwwgroup = $group ? {
-    ''      => $apache::params::group,
+    ''      => $apache_c2c::params::group,
     default => $group,
   }
 
   # used in ERB templates
-  $wwwroot = $apache::root
+  $wwwroot = $apache_c2c::root
   validate_absolute_path($wwwroot)
 
   $documentroot = $docroot ? {
@@ -58,13 +58,13 @@ define apache::vhost (
         CentOS  => 'httpd_config_t',
         default => undef,
       }
-      file { "${apache::params::conf}/sites-available/${name}":
+      file { "${apache_c2c::params::conf}/sites-available/${name}":
         ensure  => present,
         owner   => root,
         group   => root,
         mode    => '0644',
         seltype => $vhost_seltype,
-        require => Package[$apache::params::pkg],
+        require => Package[$apache_c2c::params::pkg],
         notify  => Exec['apache-graceful'],
       }
 
@@ -193,19 +193,19 @@ define apache::vhost (
       case $config_file {
 
         default: {
-          File["${apache::params::conf}/sites-available/${name}"] {
+          File["${apache_c2c::params::conf}/sites-available/${name}"] {
             source => $config_file,
           }
         }
         '': {
 
           if $config_content {
-            File["${apache::params::conf}/sites-available/${name}"] {
+            File["${apache_c2c::params::conf}/sites-available/${name}"] {
               content => $config_content,
             }
           } else {
             # default vhost template
-            File["${apache::params::conf}/sites-available/${name}"] {
+            File["${apache_c2c::params::conf}/sites-available/${name}"] {
               content => template("${module_name}/vhost.erb"),
             }
           }
@@ -259,36 +259,36 @@ define apache::vhost (
       }
 
       $enable_vhost_command = $::operatingsystem ? {
-        RedHat  => "${apache::params::a2ensite} ${name}",
-        CentOS  => "${apache::params::a2ensite} ${name}",
-        default => "${apache::params::a2ensite} ${name}"
+        RedHat  => "${apache_c2c::params::a2ensite} ${name}",
+        CentOS  => "${apache_c2c::params::a2ensite} ${name}",
+        default => "${apache_c2c::params::a2ensite} ${name}"
       }
       exec {"enable vhost ${name}":
         command => $enable_vhost_command,
         notify  => Exec['apache-graceful'],
         require => [
           $::operatingsystem ? {
-            redhat  => File[$apache::params::a2ensite],
-            CentOS  => File[$apache::params::a2ensite],
-            default => Package[$apache::params::pkg]
+            redhat  => File[$apache_c2c::params::a2ensite],
+            CentOS  => File[$apache_c2c::params::a2ensite],
+            default => Package[$apache_c2c::params::pkg]
           },
-          File["${apache::params::conf}/sites-available/${name}"],
+          File["${apache_c2c::params::conf}/sites-available/${name}"],
           File["${wwwroot}/${name}/htdocs"],
           File["${wwwroot}/${name}/logs"],
           File["${wwwroot}/${name}/conf"]
         ],
-        unless  => "/bin/sh -c '[ -L ${apache::params::conf}/sites-enabled/${name} ] \\
-          && [ ${apache::params::conf}/sites-enabled/${name} -ef ${apache::params::conf}/sites-available/${name} ]'",
+        unless  => "/bin/sh -c '[ -L ${apache_c2c::params::conf}/sites-enabled/${name} ] \\
+          && [ ${apache_c2c::params::conf}/sites-enabled/${name} -ef ${apache_c2c::params::conf}/sites-available/${name} ]'",
       }
     }
 
     absent: {
-      file { "${apache::params::conf}/sites-enabled/${name}":
+      file { "${apache_c2c::params::conf}/sites-enabled/${name}":
         ensure  => absent,
         require => Exec["disable vhost ${name}"]
       }
 
-      file { "${apache::params::conf}/sites-available/${name}":
+      file { "${apache_c2c::params::conf}/sites-available/${name}":
         ensure  => absent,
         require => Exec["disable vhost ${name}"]
       }
@@ -303,12 +303,12 @@ define apache::vhost (
         command => $disable_vhost_command,
         notify  => Exec['apache-graceful'],
         require => [$::operatingsystem ? {
-          redhat  => File[$apache::params::a2ensite],
-          CentOS  => File[$apache::params::a2ensite],
-          default => Package[$apache::params::pkg]
+          redhat  => File[$apache_c2c::params::a2ensite],
+          CentOS  => File[$apache_c2c::params::a2ensite],
+          default => Package[$apache_c2c::params::pkg]
           }],
-        onlyif  => "/bin/sh -c '[ -L ${apache::params::conf}/sites-enabled/${name} ] \\
-          && [ ${apache::params::conf}/sites-enabled/${name} -ef ${apache::params::conf}/sites-available/${name} ]'",
+        onlyif  => "/bin/sh -c '[ -L ${apache_c2c::params::conf}/sites-enabled/${name} ] \\
+          && [ ${apache_c2c::params::conf}/sites-enabled/${name} -ef ${apache_c2c::params::conf}/sites-available/${name} ]'",
       }
     }
 
@@ -316,12 +316,12 @@ define apache::vhost (
       exec { "disable vhost ${name}":
         command => $disable_vhost_command,
         notify  => Exec['apache-graceful'],
-        require => Package[$apache::params::pkg],
-        onlyif  => "/bin/sh -c '[ -L ${apache::params::conf}/sites-enabled/${name} ] \\
-          && [ ${apache::params::conf}/sites-enabled/${name} -ef ${apache::params::conf}/sites-available/${name} ]'",
+        require => Package[$apache_c2c::params::pkg],
+        onlyif  => "/bin/sh -c '[ -L ${apache_c2c::params::conf}/sites-enabled/${name} ] \\
+          && [ ${apache_c2c::params::conf}/sites-enabled/${name} -ef ${apache_c2c::params::conf}/sites-available/${name} ]'",
       }
 
-      file { "${apache::params::conf}/sites-enabled/${name}":
+      file { "${apache_c2c::params::conf}/sites-enabled/${name}":
         ensure  => absent,
         require => Exec["disable vhost ${name}"]
       }

--- a/manifests/vhost/ssl.pp
+++ b/manifests/vhost/ssl.pp
@@ -78,9 +78,9 @@
 #   $sslcert_locality="San Francisco"
 #   $sslcert_organisation="Snake Oil, Ltd."
 #
-#   include apache::ssl
+#   include apache_c2c::ssl
 #
-#   apache::vhost::ssl { "foo.example.com":
+#   apache_c2c::vhost::ssl { "foo.example.com":
 #     ensure => present,
 #     ip_address => "10.0.0.2",
 #     publish_csr => "/home/webmaster/foo.example.com.csr",
@@ -88,7 +88,7 @@
 #   }
 #
 #   # go to https://bar.example.com/bar.example.com.csr to retrieve the CSR.
-#   apache::vhost::ssl { "bar.example.com":
+#   apache_c2c::vhost::ssl { "bar.example.com":
 #     ensure => present,
 #     ip_address => "10.0.0.3",
 #     cert => "puppet:///modules/exampleproject/ssl-certs/bar.example.com.crt",
@@ -97,7 +97,7 @@
 #     sslonly => true,
 #   }
 
-define apache::vhost::ssl (
+define apache_c2c::vhost::ssl (
   $ensure=present,
   $config_file='',
   $config_content=false,
@@ -147,20 +147,20 @@ define apache::vhost::ssl (
   if ($certcn != false ) { $sslcert_commonname = $certcn }
   else { $sslcert_commonname = $name }
 
-  include apache::params
+  include apache_c2c::params
 
   $wwwuser = $user ? {
-    ''      => $apache::params::user,
+    ''      => $apache_c2c::params::user,
     default => $user,
   }
 
   $wwwgroup = $group ? {
-    ''      => $apache::params::group,
+    ''      => $apache_c2c::params::group,
     default => $group,
   }
 
   # used in ERB templates
-  $wwwroot = $apache::root
+  $wwwroot = $apache_c2c::root
   validate_absolute_path($wwwroot)
 
   $documentroot = $docroot ? {
@@ -209,7 +209,7 @@ define apache::vhost::ssl (
     false   => $_sslonly,
     default => $config_content,
   }
-  apache::vhost {$name:
+  apache_c2c::vhost {$name:
     ensure           => $ensure,
     config_file      => $config_file,
     config_content   => $_config_content,

--- a/manifests/webdav/base.pp
+++ b/manifests/webdav/base.pp
@@ -1,4 +1,4 @@
-class apache::webdav::base {
+class apache_c2c::webdav::base {
 
   case $::operatingsystem {
 
@@ -8,7 +8,7 @@ class apache::webdav::base {
         ensure => present,
       }
 
-      apache::module {'encoding':
+      apache_c2c::module {'encoding':
         ensure  => present,
         require => Package['libapache2-mod-encoding'],
       }
@@ -24,12 +24,12 @@ class apache::webdav::base {
 
   }
 
-  apache::module {['dav', 'dav_fs']:
+  apache_c2c::module {['dav', 'dav_fs']:
     ensure => present,
   }
 
-  if !defined(Apache::Module['headers']) {
-    apache::module {'headers':
+  if !defined(Apache_c2c::Module['headers']) {
+    apache_c2c::module {'headers':
       ensure => present,
     }
   }

--- a/manifests/webdav/instance.pp
+++ b/manifests/webdav/instance.pp
@@ -1,11 +1,11 @@
-define apache::webdav::instance(
+define apache_c2c::webdav::instance(
   $vhost,
   $ensure    = present,
   $directory = false,
   $mode      = '2755',
 ) {
 
-  $wwwroot = $apache::root
+  $wwwroot = $apache_c2c::root
   validate_absolute_path($wwwroot)
 
   if $directory {

--- a/manifests/webdav/ssl.pp
+++ b/manifests/webdav/ssl.pp
@@ -1,6 +1,6 @@
-class apache::webdav::ssl inherits apache::ssl {
+class apache_c2c::webdav::ssl inherits apache_c2c::ssl {
   case $::operatingsystem {
-    Debian,Ubuntu:  { include apache::webdav::ssl::debian}
+    Debian,Ubuntu:  { include apache_c2c::webdav::ssl::debian}
     default: { fail "Unsupported operatingsystem ${::operatingsystem}" }
   }
 }

--- a/manifests/webdav/ssl/debian.pp
+++ b/manifests/webdav/ssl/debian.pp
@@ -1,4 +1,4 @@
-class apache::webdav::ssl::debian inherits apache::webdav::base {
+class apache_c2c::webdav::ssl::debian inherits apache_c2c::webdav::base {
 
   case $::lsbdistcodename {
     etch: {

--- a/manifests/webdav/svn.pp
+++ b/manifests/webdav/svn.pp
@@ -1,6 +1,6 @@
-define apache::webdav::svn ($ensure, $vhost, $parentPath, $confname) {
+define apache_c2c::webdav::svn ($ensure, $vhost, $parentPath, $confname) {
 
-  $wwwroot = $apache::root
+  $wwwroot = $apache_c2c::root
   validate_absolute_path($wwwroot)
 
   $location = $name

--- a/templates/default-vhost.erb
+++ b/templates/default-vhost.erb
@@ -1,6 +1,6 @@
 # file managed by puppet
 <VirtualHost *:80>
-  DocumentRoot <%=scope.lookupvar("apache::root")%>/html
+  DocumentRoot <%=scope.lookupvar("apache_c2c::root")%>/html
   ServerName localhost
 
   <Directory />


### PR DESCRIPTION
Commands launched to generate this PR:

``` bash
find . -type f -name '*.pp' -print0 | xargs -0 sed -i -r "s/^class $from([^_])/class $to\1/"
find . -type f -name '*.pp' -print0 | xargs -0 sed -i -r "s/^define $from::/define $to::/"
find . -type f -name '*.pp' -print0 | xargs -0 sed -i -r 's@(inherits (::)?apache)([^_])@\1_c2c\3@'
find . -type f -name '*.pp' -print0 | xargs -0 sed -i -r 's@(\s+include\s+(::)?apache)([^_])@\1_c2c\3@'
find . -type f -name '*.pp' -print0 | xargs -0 sed -i -r "s@(class\s*\{\s*[\"\']?(::)apache)([^_])?@\1_c2c\3@"
find . -type f -name '*.pp' -print0 | xargs -0 sed -i -r 's@(\$\{?(::)?apache)::@\1_c2c::@g'
find . -type f -name '*.pp' -print0 | xargs -0 sed -i -r 's/^(#?\s+(@@)?apache)::/\1_c2c::/'
find . -type f -name '*.pp' -print0 | xargs -0 sed -i -r 's@Apache::@Apache_c2c::@'
find . -type f -name '*.erb' -print0 | xargs -0 sed -i -r 's@(scope.lookupvar\("apache)([^_])@\1_c2c\2@'
```
