### PR TITLE
added missing quotes for the regex — new htpasswd uses "$" symbol… not r...

### DIFF
--- a/manifests/auth/htpasswd.pp
+++ b/manifests/auth/htpasswd.pp
@@ -36,7 +36,7 @@ define apache_c2c::auth::htpasswd (
 
       if $cryptPassword {
         exec {"test -f ${_authUserFile} || OPT='-c'; htpasswd -bp \${OPT} ${_authUserFile} ${username} '${cryptPassword}'":
-          unless  => "grep -q ${username}:${cryptPassword} ${_authUserFile}",
+          unless  => "grep -q '${username}:${cryptPassword}' ${_authUserFile}",
           require => File[$_userFileLocation],
         }
       }


### PR DESCRIPTION
...eally cool with the previous regexp
