### PR TITLE
apache_c2c::vhost::ssl: create params for ssl cert infos

### DIFF
--- a/manifests/vhost/ssl.pp
+++ b/manifests/vhost/ssl.pp
@@ -45,10 +45,6 @@
 #   This is the file passed to the SSLCARevocationFile directive.
 # - *$certchain*: optional source URL of the CA certificate chain, if needed.
 #   This the certificate passed to the SSLCertificateChainFile directive.
-# - *$certcn*: set a custom CN field in your SSL certificate. Note that
-#   the CN field must match the FQDN of your virtualhost to avoid "certificate
-#   name mismatch" errors in the users browsers. Defaults to false, which means
-#   that $name will be used as the CN.
 # - *$verifyclient*: set the Certificate verification level for the Client
 #   Authentication. Must be one of 'none', 'optional', 'require' or
 #   'optional_no_ca'.
@@ -67,6 +63,17 @@
 # - *sslports*: array specifying the ports on which the SSL vhost will be
 #   reachable. Defaults to "*:443".
 # - *accesslog_format*: format string for access logs. Defaults to "combined".
+# - *$sslcert_commonname*: set a custom CN field in your SSL certificate. Note that
+#   the CN field must match the FQDN of your virtualhost to avoid "certificate
+#   name mismatch" errors in the users browsers. Defaults to $name.
+# - *$sslcert_country*: set the countryName field in your SSL certificate. Defaults
+#   to '??'.
+# - *$sslcert_state*: set the stateOrProvinceName field in your SSL certificate.
+# - *$sslcert_locality*: set the localityName field in your SSL certificate.
+# - *$sslcert_organization*: set the organizationName field in your SSL certificate.
+#    Defaults to 'undefined organisation'.
+# - *$sslcert_unit*: set the organizationalUnitName field in your SSL certificate.
+# - *$sslcert_email*: set the emailAddress field in your SSL certificate.
 #
 # Requires:
 # - Class["apache-ssl"]
@@ -119,7 +126,6 @@ define apache_c2c::vhost::ssl (
   $cacert=false,
   $cacrl=false,
   $certchain=false,
-  $certcn=false,
   $verifyclient=undef,
   $options=[],
   $days='3650',
@@ -127,7 +133,14 @@ define apache_c2c::vhost::ssl (
   $sslonly=true,
   $ports=['*:80'],
   $sslports=['*:443'],
-  $accesslog_format='combined'
+  $accesslog_format='combined',
+  $sslcert_commonname=$name,
+  $sslcert_country='??',
+  $sslcert_state=undef,
+  $sslcert_locality=undef,
+  $sslcert_organization='undefined organisation',
+  $sslcert_unit=undef,
+  $sslcert_email=undef,
 ) {
 
   # Validate parameters
@@ -139,13 +152,6 @@ define apache_c2c::vhost::ssl (
     )
   }
   validate_array($options)
-
-  # these 2 values are required to generate a valid SSL certificate.
-  if (!$sslcert_country) { $sslcert_country = '??' }
-  if (!$sslcert_organisation) {$sslcert_organisation = 'undefined organisation'}
-
-  if ($certcn != false ) { $sslcert_commonname = $certcn }
-  else { $sslcert_commonname = $name }
 
   include apache_c2c::params
 

--- a/templates/ssleay.cnf.erb
+++ b/templates/ssleay.cnf.erb
@@ -11,28 +11,28 @@ default_md              = sha1
 default_keyfile         = privkey.pem
 distinguished_name      = req_distinguished_name
 prompt                  = no
-<% unless aliases.empty? -%>
+<% unless @aliases.empty? -%>
 req_extensions          = req_ext
 <% end -%>
 
 [ req_distinguished_name ]
-countryName                     = <%= sslcert_country %>
-<% if has_variable?("sslcert_state") -%>
-stateOrProvinceName             = <%= sslcert_state %>
+countryName                     = <%= @sslcert_country %>
+<% unless @sslcert_state.nil? -%>
+stateOrProvinceName             = <%= @sslcert_state %>
 <% end -%>
-<% if has_variable?("sslcert_locality") -%>
-localityName                    = <%= sslcert_locality %>
+<% unless @sslcert_locality.nil? -%>
+localityName                    = <%= @sslcert_locality %>
 <% end -%>
-organizationName                = <%= sslcert_organisation %>
-<% if has_variable?("sslcert_unit") -%>
-organizationalUnitName          = <%= sslcert_unit %>
+organizationName                = <%= @sslcert_organization %>
+<% unless @sslcert_unit.nil? -%>
+organizationalUnitName          = <%= @sslcert_unit %>
 <% end -%>
-commonName                      = <%= sslcert_commonname %>
-<% if has_variable?("sslcert_email") -%>
-emailAddress                    = <%= sslcert_email %>
+commonName                      = <%= @sslcert_commonname %>
+<% unless @sslcert_email.nil? -%>
+emailAddress                    = <%= @sslcert_email %>
 <% end -%>
 
-<% unless aliases.empty? -%>
+<% unless @aliases.empty? -%>
 [ req_ext ]
-subjectAltName = "<%= aliases.collect! {|i| "DNS: #{i}" }.join(', ') -%>"
+subjectAltName = "<%= [@aliases].flatten.collect {|i| "DNS: #{i}" }.join(', ') -%>"
 <% end %>


### PR DESCRIPTION
Was using dynamically scoped variables that won't work with puppet 3.
Created parameters sslcert_\* for all certificate fields, changed the
certcn param to sslcert_commonname for consistency and to make existing
recipes fail instead of breaking the configuration.

This change is not backwards compatible and will require fixing code setting
ssl cert values.
