### PR TITLE
Fix POODLE mitigation patch

### DIFF
--- a/manifests/ssl/debian.pp
+++ b/manifests/ssl/debian.pp
@@ -7,8 +7,12 @@ class apache_c2c::ssl::debian inherits apache_c2c::base::ssl {
     augeas {'disable SSLv3 cipher':
       incl    => '/etc/apache2/mods-available/ssl.conf',
       lens    => 'Httpd.lns',
-      changes => ["set IfModule/*[self::directive='SSLProtocol']/arg[last()+1] -SSLv3"],
-      onlyif  => "match IfModule/*[self::directive='SSLProtocol']/arg not_include '-SSLv3'",
+      changes => [
+        "rm IfModule/*[self::directive='SSLProtocol']/arg",
+        "set IfModule/*[self::directive='SSLProtocol']/arg[1] all",
+        "set IfModule/*[self::directive='SSLProtocol']/arg[2] -SSLv2",
+        "set IfModule/*[self::directive='SSLProtocol']/arg[3] -SSLv3",
+        ],
       require => Package['httpd'],
       notify  => Service['httpd'],
     }


### PR DESCRIPTION
augeas' onlyif doesn't seem to work, or just likes to fail silently
for the sake of it. Anyway, let's set the the whole SSLProtocol directive.
