### PR TITLE
Add param to disable logrotate conf management

### DIFF
--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -93,14 +93,16 @@ class apache_c2c::base {
     }
   }
 
-  file {'logrotate configuration':
-    ensure  => present,
-    path    => undef,
-    owner   => root,
-    group   => root,
-    mode    => '0644',
-    source  => undef,
-    require => Package['httpd'],
+  if $::apache_c2c::manage_logrotate_conf {
+    file {'logrotate configuration':
+      ensure  => present,
+      path    => undef,
+      owner   => root,
+      group   => root,
+      mode    => '0644',
+      source  => undef,
+      require => Package['httpd'],
+    }
   }
 
   if ! $apache_c2c::disable_port80 {

--- a/manifests/debian.pp
+++ b/manifests/debian.pp
@@ -9,15 +9,17 @@ class apache_c2c::debian inherits apache_c2c::base {
     command => 'apache2ctl graceful',
   }
 
-  # the following variables are used in template logrotate-httpd.erb
-  $logrotate_paths = "${wwwroot}/*/logs/*.log ${apache_c2c::params::log}/*log"
-  $httpd_pid_file = '/var/run/apache2.pid'
-  $httpd_reload_cmd = '/etc/init.d/apache2 restart > /dev/null'
-  $awstats_condition = '-f /usr/share/doc/awstats/examples/awstats_updateall.pl -a -f /usr/lib/cgi-bin/awstats.pl'
-  $awstats_command = '/usr/share/doc/awstats/examples/awstats_updateall.pl -awstatsprog=/usr/lib/cgi-bin/awstats.pl -confdir=/etc/awstats now > /dev/null'
-  File['logrotate configuration'] {
-    path    => '/etc/logrotate.d/apache2',
-    content => template('apache_c2c/logrotate-httpd.erb'),
+  if $::apache_c2c::manage_logrotate_conf {
+    # the following variables are used in template logrotate-httpd.erb
+    $logrotate_paths = "${wwwroot}/*/logs/*.log ${apache_c2c::params::log}/*log"
+    $httpd_pid_file = '/var/run/apache2.pid'
+    $httpd_reload_cmd = '/etc/init.d/apache2 restart > /dev/null'
+    $awstats_condition = '-f /usr/share/doc/awstats/examples/awstats_updateall.pl -a -f /usr/lib/cgi-bin/awstats.pl'
+    $awstats_command = '/usr/share/doc/awstats/examples/awstats_updateall.pl -awstatsprog=/usr/lib/cgi-bin/awstats.pl -confdir=/etc/awstats now > /dev/null'
+    File['logrotate configuration'] {
+      path    => '/etc/logrotate.d/apache2',
+      content => template('apache_c2c/logrotate-httpd.erb'),
+    }
   }
 
   if $::apache_c2c::backend != 'puppetlabs' {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,18 +28,20 @@
 #   include apache
 #
 class apache_c2c (
-  $root            = $apache_c2c::params::root,
-  $service_ensure  = 'running',
-  $service_enable  = true,
-  $disable_port80  = false,
-  $default_vhost   = true,
-  $backend         = 'camptocamp',
+  $root                  = $apache_c2c::params::root,
+  $service_ensure        = 'running',
+  $service_enable        = true,
+  $disable_port80        = false,
+  $default_vhost         = true,
+  $backend               = 'camptocamp',
+  $manage_logrotate_conf = true,
 ) inherits ::apache_c2c::params {
 
   validate_absolute_path ($root)
   validate_re ($service_ensure, 'running|stopped|unmanaged')
   validate_bool ($service_enable)
   validate_bool ($disable_port80)
+  validate_bool ($manage_logrotate_conf)
 
   case $::osfamily {
     'Debian': { include apache_c2c::debian}

--- a/manifests/redhat.pp
+++ b/manifests/redhat.pp
@@ -9,18 +9,20 @@ class apache_c2c::redhat inherits apache_c2c::base {
     command => 'apachectl graceful',
   }
 
-  # the following variables are used in template logrotate-httpd.erb
-  $logrotate_paths = "${wwwroot}/*/logs/*.log ${apache_c2c::params::log}/*log"
-  $httpd_pid_file = $::operatingsystemmajrelease ? {
-    /4|5/   => '/var/run/httpd.pid',
-    default => '/var/run/httpd/httpd.pid',
-  }
-  $httpd_reload_cmd = '/sbin/service httpd reload > /dev/null 2> /dev/null || true'
-  $awstats_condition = '-x /etc/cron.hourly/awstats'
-  $awstats_command = '/etc/cron.hourly/awstats || true'
-  File['logrotate configuration'] {
-    path    => '/etc/logrotate.d/httpd',
-    content => template('apache_c2c/logrotate-httpd.erb'),
+  if $::apache_c2c::manage_logrotate_conf {
+    # the following variables are used in template logrotate-httpd.erb
+    $logrotate_paths = "${wwwroot}/*/logs/*.log ${apache_c2c::params::log}/*log"
+    $httpd_pid_file = $::operatingsystemmajrelease ? {
+      /4|5/   => '/var/run/httpd.pid',
+      default => '/var/run/httpd/httpd.pid',
+    }
+    $httpd_reload_cmd = '/sbin/service httpd reload > /dev/null 2> /dev/null || true'
+    $awstats_condition = '-x /etc/cron.hourly/awstats'
+    $awstats_command = '/etc/cron.hourly/awstats || true'
+    File['logrotate configuration'] {
+      path    => '/etc/logrotate.d/httpd',
+      content => template('apache_c2c/logrotate-httpd.erb'),
+    }
   }
 
   if $::apache_c2c::backend != 'puppetlabs' {


### PR DESCRIPTION
Planned use case is a server where we want a custom setup to
avoid automatic awstats runs on log rotation.
