### PR TITLE
SELinux files type defined in policy RHEL6

### DIFF
--- a/manifests/awstats.pp
+++ b/manifests/awstats.pp
@@ -33,17 +33,29 @@ class apache_c2c::awstats {
 
       # awstats RPM installs its own cron in /etc/cron.hourly/awstats
 
-      file { '/usr/share/awstats/wwwroot/cgi-bin/':
-        seltype => 'httpd_sys_script_exec_t',
-        mode    => '0755',
-        recurse => true,
-        require => Package['awstats'],
-      }
+      case $::operatingsystemmajrelease {
+        '5': {
+          file { '/usr/share/awstats/wwwroot/cgi-bin/':
+            seltype => 'httpd_sys_script_exec_t',
+            mode    => '0755',
+            recurse => true,
+            require => Package['awstats'],
+          }
 
-      file { '/var/lib/awstats/':
-        seltype => 'httpd_sys_script_ro_t',
-        recurse => true,
-        require => Package['awstats'],
+          file { '/var/lib/awstats/':
+            seltype => 'httpd_sys_script_ro_t',
+            recurse => true,
+            require => Package['awstats'],
+          }
+        }
+        '6': {
+          file { '/usr/share/awstats/wwwroot/cgi-bin/':
+            mode    => '0755',
+            recurse => true,
+            require => Package['awstats'],
+          }
+        }
+        default: { fail "Module 'apache_c2c' not compatible with this distro, use 'puppetlabs-apache' instead" }
       }
 
       file { '/etc/httpd/conf.d/awstats.conf':

--- a/spec/classes/apache_awstats_spec.rb
+++ b/spec/classes/apache_awstats_spec.rb
@@ -28,18 +28,25 @@ describe 'apache_c2c::awstats' do
 
         it { should contain_file('/etc/cron.d/awstats').with_ensure('absent') }
       when 'RedHat'
-        it do should contain_file('/usr/share/awstats/wwwroot/cgi-bin/').with(
-          'seltype' => 'httpd_sys_script_exec_t',
-          'mode'    => '0755',
-          'recurse' => 'true'
-        ) end
-
-        it do should contain_file('/var/lib/awstats/').with(
-          'seltype' => 'httpd_sys_script_ro_t',
-          'recurse' => 'true'
-        ) end
-
         it { should contain_file('/etc/httpd/conf.d/awstats.conf').with_ensure('absent') }
+        case facts[:operatingsystemmajrelease]
+        when '5'
+          it do should contain_file('/usr/share/awstats/wwwroot/cgi-bin/').with(
+            'seltype' => 'httpd_sys_script_exec_t',
+            'mode'    => '0755',
+            'recurse' => 'true'
+          ) end
+ 
+          it do should contain_file('/var/lib/awstats/').with(
+            'seltype' => 'httpd_sys_script_ro_t',
+            'recurse' => 'true'
+          ) end
+        when '6'
+          it do should contain_file('/usr/share/awstats/wwwroot/cgi-bin/').with(
+            'mode'    => '0755',
+            'recurse' => 'true'
+          ) end
+        end
       end
     end
   end


### PR DESCRIPTION
RHEL6 provide new type for awstat, don't override them.